### PR TITLE
Pass down View & MotionEvent to listeners

### DIFF
--- a/app/src/main/java/com/skydoves/balloondemo/MainActivity.kt
+++ b/app/src/main/java/com/skydoves/balloondemo/MainActivity.kt
@@ -69,7 +69,7 @@ class MainActivity : AppCompatActivity(), SampleViewHolder.Delegate, OnBalloonCl
     }
   }
 
-  override fun onBalloonClick() {
+  override fun onBalloonClick(view: View) {
     navigationBalloon.dismiss()
     Toast.makeText(baseContext, "dismissed", Toast.LENGTH_SHORT).show()
   }

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -147,7 +147,7 @@ class Balloon(
     this.onBalloonDismissListener = builder.onBalloonDismissListener
     this.onBalloonOutsideTouchListener = builder.onBalloonOutsideTouchListener
     this.bodyView.setOnClickListener {
-      this.onBalloonClickListener?.onBalloonClick()
+      this.onBalloonClickListener?.onBalloonClick(it)
       if (builder.dismissWhenClicked) dismiss()
     }
     this.bodyWindow.setOnDismissListener { this.onBalloonDismissListener?.onBalloonDismiss() }
@@ -160,7 +160,7 @@ class Balloon(
           dismiss()
         }
         if (event.action == MotionEvent.ACTION_OUTSIDE) {
-          onBalloonOutsideTouchListener?.onBalloonOutsideTouch()
+          onBalloonOutsideTouchListener?.onBalloonOutsideTouch(view, event)
           return true
         }
         return false
@@ -526,7 +526,7 @@ class Balloon(
     /** sets a [OnBalloonClickListener] to the popup using lambda. */
     fun setOnBalloonClickListener(unit: () -> Unit): Builder = apply {
       this.onBalloonClickListener = object : OnBalloonClickListener {
-        override fun onBalloonClick() {
+        override fun onBalloonClick(view: View) {
           unit()
         }
       }
@@ -544,7 +544,10 @@ class Balloon(
     /** sets a [OnBalloonOutsideTouchListener] to the popup using lambda. */
     fun setOnBalloonOutsideTouchListener(unit: () -> Unit): Builder = apply {
       this.onBalloonOutsideTouchListener = object : OnBalloonOutsideTouchListener {
-        override fun onBalloonOutsideTouch() {
+        override fun onBalloonOutsideTouch(
+          view: View,
+          event: MotionEvent
+        ) {
           unit()
         }
       }

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -524,10 +524,10 @@ class Balloon(
     fun setOnBalloonOutsideTouchListener(value: OnBalloonOutsideTouchListener): Builder = apply { this.onBalloonOutsideTouchListener = value }
 
     /** sets a [OnBalloonClickListener] to the popup using lambda. */
-    fun setOnBalloonClickListener(unit: () -> Unit): Builder = apply {
+    fun setOnBalloonClickListener(unit: (View) -> Unit): Builder = apply {
       this.onBalloonClickListener = object : OnBalloonClickListener {
         override fun onBalloonClick(view: View) {
-          unit()
+          unit(view)
         }
       }
     }
@@ -542,13 +542,13 @@ class Balloon(
     }
 
     /** sets a [OnBalloonOutsideTouchListener] to the popup using lambda. */
-    fun setOnBalloonOutsideTouchListener(unit: () -> Unit): Builder = apply {
+    fun setOnBalloonOutsideTouchListener(unit: (View, MotionEvent) -> Unit): Builder = apply {
       this.onBalloonOutsideTouchListener = object : OnBalloonOutsideTouchListener {
         override fun onBalloonOutsideTouch(
           view: View,
           event: MotionEvent
         ) {
-          unit()
+          unit(view, event)
         }
       }
     }

--- a/balloon/src/main/java/com/skydoves/balloon/OnBalloonClickListener.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/OnBalloonClickListener.kt
@@ -16,7 +16,9 @@
 
 package com.skydoves.balloon
 
+import android.view.View
+
 /** Interface definition for a callback to be invoked when a balloon view is clicked. */
 interface OnBalloonClickListener {
-  fun onBalloonClick()
+  fun onBalloonClick(view: View)
 }

--- a/balloon/src/main/java/com/skydoves/balloon/OnBalloonOutsideTouchListener.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/OnBalloonOutsideTouchListener.kt
@@ -16,7 +16,10 @@
 
 package com.skydoves.balloon
 
+import android.view.MotionEvent
+import android.view.View
+
 /** Interface definition for a callback to be invoked when touched on outside of the balloon popup. */
 interface OnBalloonOutsideTouchListener {
-    fun onBalloonOutsideTouch()
+    fun onBalloonOutsideTouch(view: View, event: MotionEvent)
 }


### PR DESCRIPTION
## Guidelines
I have a use case where I need a reference to the touched view  & location
- [ ] Breaking change  -> signature of 
OnBalloonOutsideTouchListener#onBalloonOutsideTouch() & OnBalloonClickListener#onBalloonClick() is changed