### PR TITLE
dismissing when the dialog touched (but not clicked) fixed

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -167,10 +167,10 @@ class Balloon(
       setTouchInterceptor(object : View.OnTouchListener {
         @SuppressLint("ClickableViewAccessibility")
         override fun onTouch(view: View, event: MotionEvent): Boolean {
-          if (builder.dismissWhenTouchOutside) {
-            dismiss()
-          }
           if (event.action == MotionEvent.ACTION_OUTSIDE) {
+            if (builder.dismissWhenTouchOutside) {
+              dismiss()
+            }
             onBalloonOutsideTouchListener?.onBalloonOutsideTouch(view, event)
             return true
           }


### PR DESCRIPTION
## Guidelines
If the option `dismissWhenTouchOutside` is true and when the ballon content is just touched, but not clicked yet, the balloon dismisses. So I suggest to move the dismiss into the if block where  event.action is checked for MotionEvent.ACTION_OUTSIDE.

### Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue), Ballon#initializeBalloonListeners