### PR TITLE
Fixed crash on relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Balloon balloon = new Balloon.Builder(context)
     .setArrowPosition(0.62f)
     .setCornerRadius(4f)
     .setAlpha(0.9f)
-    .setText("You can access your profile from on now.")
+    .setText("You can access your profile from now on.")
     .setTextColor(ContextCompat.getColor(context, R.color.white_93))
     .setIconDrawable(ContextCompat.getDrawable(context, R.drawable.ic_profile))
     .setBackgroundColor(ContextCompat.getColor(context, R.color.colorPrimary))
@@ -74,7 +74,7 @@ val balloon = createBalloon(context) {
   setArrowPosition(0.7f)
   setCornerRadius(4f)
   setAlpha(0.9f)
-  setText("You can access your profile from on now.")
+  setText("You can access your profile from now on.")
   setTextColorResource(R.color.white_93)
   setIconDrawable(ContextCompat.getDrawable(context, R.drawable.ic_profile))
   setBackgroundColorResource(R.color.colorPrimary)
@@ -101,7 +101,7 @@ balloon.setHeight(160) // sets 160dp size height.
 ```
 #### According to screen ratio
 Also, we can set the width according to the ratio of the horizontal screen's size.
-```kotin
+```kotlin
 balloon.setWidthRatio(0.5f) // sets width as 50% of the horizontal screen's size.
 ```
 
@@ -126,7 +126,7 @@ balloon.showAlignLeft(anchor: View, xOff: Int, yOff: Int) // shows left alignmen
 Or we can show balloon popup using kotlin extension.
 
 ```java
-myButtom.showAlignTop(balloon)
+myButton.showAlignTop(balloon)
 ```
 We can dismiss popup simply using `Balloon.dismiss()` method.
 ```java
@@ -279,7 +279,7 @@ We can simplify it using kotlin.
 ### Customized layout
 We can fully customize the balloon layout using below method.
 ```java
-.setLayout(R.layout.my_ballon_layout)
+.setLayout(R.layout.my_balloon_layout)
 ```
 
 This is an example of implementing custom balloon popup.
@@ -337,7 +337,7 @@ Just use `setLifecycleOwner` method. Then `dismiss` method will be called automa
 ```
 
 ### Lazy initialization
-We can initialize the ballloon property lazily using `balloon` keyword and `Balloon.Factory` abstract class.<br>
+We can initialize the balloon property lazily using `balloon` keyword and `Balloon.Factory` abstract class.<br>
 The `balloon` extension keyword can be used on `Activity` and `Fragment`.
 
 __Before__<br>
@@ -426,7 +426,7 @@ FADE | OVERSHOOT | ELASTIC | CIRCULAR |
 .setText(value: String)
 .setTextResource(value: Int)
 .setTextColor(value: Int)
-.setTextColorResoure(value: Int)
+.setTextColorResource(value: Int)
 .setTextSize(value: Float)
 .setTextTypeface(value: Int)
 .setTextForm(value: TextForm)

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -76,6 +76,7 @@ class Balloon(
   private val bodyWindow: PopupWindow
   var isShowing = false
     private set
+  private var destroyed: Boolean = false
   var onBalloonClickListener: OnBalloonClickListener? = null
   var onBalloonDismissListener: OnBalloonDismissListener? = null
   var onBalloonOutsideTouchListener: OnBalloonOutsideTouchListener? = null
@@ -306,7 +307,11 @@ class Balloon(
     balloon: Balloon,
     crossinline block: (balloon: Balloon) -> Unit
   ): Balloon {
-    this.setOnBalloonDismissListener { block(balloon) }
+    this.setOnBalloonDismissListener {
+      if (!destroyed) {
+        block(balloon)
+      }
+    }
     return balloon
   }
 
@@ -612,6 +617,7 @@ class Balloon(
   /** dismiss automatically when lifecycle owner is destroyed. */
   @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
   fun onDestroy() {
+    destroyed = true
     dismiss()
   }
 


### PR DESCRIPTION
## Changes
I was using your library and came across a crash. Here are the steps to reproduce:

1. Create 2 or more balloons
2. Connect them using one of the `relay` methods, e.g. `relayShowAlignTop`
3. Make sure to also register a lifecycle owner
4. Make the first balloon show (e.g. from within the activity's `onCreate`)
5. Destroy the activity while the first balloon is shown (e.g. by rotating the device)

This results in a crash because the first balloon is dismissed automatically when the activity is destroyed (via the lifecycle observer), but this triggers the second balloon, which now tries to show up but the activity is already destroyed, leading to a crash.

I have fixed this by adding a field `destroyed` which prevents the relayed balloons from showing up.

I also fixed a few typos in the README.md.

### Types of changes
What types of changes does your code introduce?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)