### PR TITLE
Add support for setting text with HTML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Balloon balloon = new Balloon.Builder(context)
     .setAlpha(0.9f)
     .setText("You can access your profile from now on.")
     .setTextColor(ContextCompat.getColor(context, R.color.white_93))
+    .setTextIsHtml(true)
     .setIconDrawable(ContextCompat.getDrawable(context, R.drawable.ic_profile))
     .setBackgroundColor(ContextCompat.getColor(context, R.color.colorPrimary))
     .setOnBalloonClickListener(onBalloonClickListener)
@@ -76,6 +77,7 @@ val balloon = createBalloon(context) {
   setAlpha(0.9f)
   setText("You can access your profile from now on.")
   setTextColorResource(R.color.white_93)
+  setTextIsHtml(true)
   setIconDrawable(ContextCompat.getDrawable(context, R.drawable.ic_profile))
   setBackgroundColorResource(R.color.colorPrimary)
   setOnBalloonClickListener(onBalloonClickListener)
@@ -183,6 +185,13 @@ We can customize the text on the balloon popup.
 .setTextTypeface(Typeface.BOLD)
 .setTextColor(ContextCompat.getColor(context, R.color.white_87))
 ```
+
+If your text has HTML in it, you can enable HTML rendering by adding this:
+```java
+.setTextIsHtml(true)
+```
+
+This will parse the text using `Html.fromHtml(text)`.
 
 ### TextForm
 TextFrom is an attribute class that has some attributes about TextView for customizing popup text.

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -231,6 +231,7 @@ class Balloon(
         setText(builder.text)
         setTextSize(builder.textSize)
         setTextColor(builder.textColor)
+        setTextIsHtml(builder.textIsHtml)
         setTextTypeface(builder.textTypeface)
         setTextTypeface(builder.textTypefaceObject)
       })
@@ -657,6 +658,8 @@ class Balloon(
     var text: String = ""
     @JvmField @ColorInt
     var textColor: Int = Color.WHITE
+    @JvmField
+    var textIsHtml: Boolean = false
     @JvmField @Sp
     var textSize: Float = 12f
     @JvmField
@@ -820,6 +823,9 @@ class Balloon(
     fun setTextColorResource(@ColorRes value: Int): Builder = apply {
       this.textColor = context.contextColor(value)
     }
+
+    /** sets whether the text will be parsed as HTML (using Html.fromHtml(..)) */
+    fun setTextIsHtml(value: Boolean): Builder = apply { this.textIsHtml = value }
 
     /** sets the size of the main text content. */
     fun setTextSize(@Sp value: Float): Builder = apply { this.textSize = value }

--- a/balloon/src/main/java/com/skydoves/balloon/TextForm.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/TextForm.kt
@@ -42,6 +42,7 @@ class TextForm(builder: Builder) {
   val text: String = builder.text
   @Sp val textSize: Float = builder.textSize
   @ColorInt val textColor: Int = builder.textColor
+  val textIsHtml: Boolean = builder.textIsHtml
   val textStyle: Int = builder.textTypeface
   val textTypeface: Typeface? = builder.textTypefaceObject
 
@@ -54,6 +55,8 @@ class TextForm(builder: Builder) {
     var textSize: Float = 12f
     @JvmField @ColorInt
     var textColor = Color.WHITE
+    @JvmField
+    var textIsHtml: Boolean = false
     @JvmField
     var textTypeface = Typeface.NORMAL
     @JvmField
@@ -72,6 +75,9 @@ class TextForm(builder: Builder) {
 
     /** sets the color of the text. */
     fun setTextColor(@ColorInt value: Int): Builder = apply { this.textColor = value }
+
+    /** sets whether the text will be parsed as HTML (using Html.fromHtml(..)) */
+    fun setTextIsHtml(value: Boolean): Builder = apply { this.textIsHtml = value }
 
     /** sets the color of the text using resource. */
     fun setTextColorResource(@ColorRes value: Int): Builder = apply {

--- a/balloon/src/main/java/com/skydoves/balloon/TextViewExtension.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/TextViewExtension.kt
@@ -16,12 +16,16 @@
 
 package com.skydoves.balloon
 
+import android.text.Html
 import android.widget.TextView
 
 /** applies text form attributes to a TextView instance. */
 @Suppress("unused")
 internal fun TextView.applyTextForm(textForm: TextForm) {
-  text = textForm.text
+  text = when (textForm.textIsHtml) {
+    true -> Html.fromHtml(textForm.text)
+    false -> textForm.text
+  }
   textSize = textForm.textSize
   setTextColor(textForm.textColor)
   textForm.textTypeface?.let { typeface = it } ?: setTypeface(typeface, textForm.textStyle)

--- a/balloon/src/main/java/com/skydoves/balloon/TextViewExtension.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/TextViewExtension.kt
@@ -16,17 +16,27 @@
 
 package com.skydoves.balloon
 
+import android.os.Build
 import android.text.Html
+import android.text.Spanned
 import android.widget.TextView
 
 /** applies text form attributes to a TextView instance. */
 @Suppress("unused")
 internal fun TextView.applyTextForm(textForm: TextForm) {
   text = when (textForm.textIsHtml) {
-    true -> Html.fromHtml(textForm.text)
+    true -> fromHtml(textForm.text)
     false -> textForm.text
   }
   textSize = textForm.textSize
   setTextColor(textForm.textColor)
   textForm.textTypeface?.let { typeface = it } ?: setTypeface(typeface, textForm.textStyle)
+}
+
+private inline fun fromHtml(text: String): Spanned? {
+  return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+    Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY)
+  } else {
+    Html.fromHtml(text)
+  }
 }


### PR DESCRIPTION
This is a new feature that allows setting text
with HTML tags as the tooltip text. This allows
basic formatting like **bold** or _italic_ for the
text inside the tooltip. Defaults to `false`.