### PR TITLE
Setter for custom layout view instead of resource

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -91,11 +91,13 @@ class Balloon(
     initializeBalloonContent()
     initializeBalloonListeners()
 
-    if (builder.layout == NO_INT_VALUE) {
+    if (builder.layoutRes != NO_INT_VALUE) {
+      initializeCustomLayoutWithResource()
+    } else if (builder.layout != null) {
+      initializeCustomLayoutWithView()
+    } else {
       initializeIcon()
       initializeText()
-    } else {
-      initializeCustomLayout()
     }
     builder.lifecycleOwner?.lifecycle?.addObserver(this@Balloon)
   }
@@ -244,10 +246,15 @@ class Balloon(
     }
   }
 
-  private fun initializeCustomLayout() {
+  private fun initializeCustomLayoutWithResource() {
     binding.balloonDetail.removeAllViews()
     val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-    inflater.inflate(builder.layout, binding.balloonDetail)
+    inflater.inflate(builder.layoutRes, binding.balloonDetail)
+  }
+
+  private fun initializeCustomLayoutWithView() {
+    binding.balloonDetail.removeAllViews()
+    binding.balloonDetail.addView(builder.layout)
   }
 
   private fun applyBalloonAnimation() {
@@ -683,7 +690,9 @@ class Balloon(
     @JvmField
     var elevation: Float = context.dp2Px(2f)
     @JvmField @LayoutRes
-    var layout: Int = NO_INT_VALUE
+    var layoutRes: Int = NO_INT_VALUE
+    @JvmField
+    var layout: View? = null
     @JvmField
     var onBalloonClickListener: OnBalloonClickListener? = null
     @JvmField
@@ -876,7 +885,10 @@ class Balloon(
     }
 
     /** sets the custom layout resource to the popup content. */
-    fun setLayout(@LayoutRes layout: Int): Builder = apply { this.layout = layout }
+    fun setLayout(@LayoutRes layoutRes: Int): Builder = apply { this.layoutRes = layoutRes }
+
+    /** sets the custom layout view to the popup content. */
+    fun setLayout(layout: View): Builder = apply { this.layout = layout }
 
     /**
      * sets the [LifecycleOwner] for dismissing automatically when the [LifecycleOwner] is destroyed.


### PR DESCRIPTION
## Guidelines
This commit adds a method overload for `setLayout` from which the user can specify a programmatically created `View` instead of just inputting an XML layout resource.

### Types of changes
What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Preparing a pull request for review
`./gradlew spotlessApply` runs successfully.