### PR TITLE
[Enhancement] Added support for clickable HTML links by exposing the movementMethod attribute of TextView in builders

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -31,6 +31,7 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.text.method.MovementMethod
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -368,6 +369,7 @@ class Balloon(
           setTextGravity(builder.textGravity)
           setTextTypeface(builder.textTypeface)
           setTextTypeface(builder.textTypefaceObject)
+          setMovementMethod(movementMethod)
         }
       )
       measureTextWidth(this)
@@ -903,6 +905,9 @@ class Balloon(
     @JvmField
     var textIsHtml: Boolean = false
 
+    @JvmField
+    var movementMethod: MovementMethod? = null
+
     @JvmField @Sp
     var textSize: Float = 12f
 
@@ -1222,6 +1227,9 @@ class Balloon(
 
     /** sets whether the text will be parsed as HTML (using Html.fromHtml(..)) */
     fun setTextIsHtml(value: Boolean): Builder = apply { this.textIsHtml = value }
+
+    /**sets the movement method for TextView */
+    fun setMovementMethod(movementMethod: MovementMethod): Builder = apply { this.movementMethod = movementMethod }
 
     /** sets the size of the main text content. */
     fun setTextSize(@Sp value: Float): Builder = apply { this.textSize = value }

--- a/balloon/src/main/java/com/skydoves/balloon/TextForm.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/TextForm.kt
@@ -21,6 +21,7 @@ package com.skydoves.balloon
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
+import android.text.method.MovementMethod
 import android.view.Gravity
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
@@ -45,6 +46,7 @@ class TextForm(builder: Builder) {
   @Sp val textSize: Float = builder.textSize
   @ColorInt val textColor: Int = builder.textColor
   val textIsHtml: Boolean = builder.textIsHtml
+  val movementMethod: MovementMethod? = builder.movementMethod
   val textStyle: Int = builder.textTypeface
   val textTypeface: Typeface? = builder.textTypefaceObject
   val textGravity: Int = builder.textGravity
@@ -63,6 +65,9 @@ class TextForm(builder: Builder) {
 
     @JvmField
     var textIsHtml: Boolean = false
+
+    @JvmField
+    var movementMethod: MovementMethod? = null
 
     @JvmField
     var textTypeface = Typeface.NORMAL
@@ -89,6 +94,9 @@ class TextForm(builder: Builder) {
 
     /** sets whether the text will be parsed as HTML (using Html.fromHtml(..)) */
     fun setTextIsHtml(value: Boolean): Builder = apply { this.textIsHtml = value }
+
+    /**sets the movement method for TextView */
+    fun setMovementMethod(movementMethod: MovementMethod): Builder = apply { this.movementMethod = movementMethod }
 
     /** sets the color of the text using resource. */
     fun setTextColorResource(@ColorRes value: Int): Builder = apply {

--- a/balloon/src/main/java/com/skydoves/balloon/extensions/TextViewExtension.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/extensions/TextViewExtension.kt
@@ -36,6 +36,7 @@ internal fun TextView.applyTextForm(textForm: TextForm) {
   gravity = textForm.textGravity
   setTextColor(textForm.textColor)
   textForm.textTypeface?.let { typeface = it } ?: setTypeface(typeface, textForm.textStyle)
+  textForm.movementMethod?.let { movementMethod = it }
 }
 
 private fun fromHtml(text: String): Spanned? {


### PR DESCRIPTION
Library already supports HTML text formatting.
However, in my case, the HTML text also had hyperlinks and I had a requirement to make them clickable.

I've added a var for movementMethod in both Balloon and Textform builders for users to enable this feature by supplying the required MovementMethod by them.