### PR TITLE
Change applying height of the bodyWindow criteria

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -578,7 +578,9 @@ class Balloon(
         initializeText()
         this.binding.root.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
         this.bodyWindow.width = getMeasuredWidth()
-        this.bodyWindow.height = getMeasuredHeight()
+        if (builder.height != BalloonSizeSpec.WRAP) {
+          this.bodyWindow.height = getMeasuredHeight()
+        }
         this.binding.balloonText.layoutParams = FrameLayout.LayoutParams(
           FrameLayout.LayoutParams.MATCH_PARENT,
           FrameLayout.LayoutParams.MATCH_PARENT


### PR DESCRIPTION
The measured height of the body content is the actual same value as the height of the body window.
But as we can see below its behavior is a little bit different. It seems a bug (PopupWindow).

## Related Issue
#171 

### Before vs After
<img src="https://user-images.githubusercontent.com/24237865/112306265-fa9ca700-8ce2-11eb-892c-b5477e204052.png" width="33%" /> <img src="https://user-images.githubusercontent.com/24237865/112306272-fbcdd400-8ce2-11eb-9bf3-179967e09f6e.png" width="33%" />
