### PR TITLE
Deprecate IconGravity.LEFT and IconGravity.RIGHT

### DIFF
--- a/app/src/main/java/com/skydoves/balloondemo/factory/ViewHolderBalloonFactory.kt
+++ b/app/src/main/java/com/skydoves/balloondemo/factory/ViewHolderBalloonFactory.kt
@@ -56,7 +56,7 @@ class ViewHolderBalloonFactory : Balloon.Factory() {
       setOnBalloonDismissListener {
         Toast.makeText(context, "dismissed", Toast.LENGTH_SHORT).show()
       }
-      setIconGravity(IconGravity.RIGHT)
+      setIconGravity(IconGravity.END)
       setDismissWhenClicked(true)
       setDismissWhenShowAgain(true)
       setBalloonAnimation(BalloonAnimation.ELASTIC)

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1260,7 +1260,7 @@ class Balloon(
 
     @JvmField
     @set:JvmSynthetic
-    var iconGravity = IconGravity.LEFT
+    var iconGravity = IconGravity.START
 
     @JvmField @Px
     @set:JvmSynthetic

--- a/balloon/src/main/java/com/skydoves/balloon/IconGravity.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/IconGravity.kt
@@ -18,8 +18,26 @@ package com.skydoves.balloon
 
 /** IconGravity determines the orientation of the icon. */
 enum class IconGravity {
+  @Deprecated(
+    message = "IconGravity.LEFT is deprecated. Use IconGravity.START instead.",
+    replaceWith = ReplaceWith(
+      "IconGravity.START",
+      imports = ["com.skydoves.balloon"]
+    )
+  )
   LEFT,
+
+  @Deprecated(
+    message = "IconGravity.LEFT is deprecated. Use IconGravity.END instead.",
+    replaceWith = ReplaceWith(
+      "IconGravity.END",
+      imports = ["com.skydoves.balloon"]
+    )
+  )
   RIGHT,
+
+  START,
+  END,
   TOP,
   BOTTOM
 }

--- a/balloon/src/main/java/com/skydoves/balloon/extensions/TextViewExtension.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/extensions/TextViewExtension.kt
@@ -53,6 +53,7 @@ private fun fromHtml(text: String): Spanned? {
 }
 
 /** applies icon form attributes to a ImageView instance. */
+@Suppress("DEPRECATION")
 internal fun VectorTextView.applyIconForm(iconForm: IconForm) {
   iconForm.drawable?.let {
     drawableTextViewParams = VectorTextViewParams(
@@ -62,9 +63,9 @@ internal fun VectorTextView.applyIconForm(iconForm: IconForm) {
       tintColor = iconForm.iconColor.takeIf { it != NO_INT_VALUE }
     ).apply {
       when (iconForm.iconGravity) {
-        IconGravity.LEFT -> {
-          drawableLeft = iconForm.drawable
-          drawableLeftRes = iconForm.drawableRes
+        IconGravity.LEFT, IconGravity.START -> {
+          drawableStart = iconForm.drawable
+          drawableStartRes = iconForm.drawableRes
         }
         IconGravity.TOP -> {
           drawableTop = iconForm.drawable
@@ -74,9 +75,9 @@ internal fun VectorTextView.applyIconForm(iconForm: IconForm) {
           drawableBottom = iconForm.drawable
           drawableBottomRes = iconForm.drawableRes
         }
-        IconGravity.RIGHT -> {
-          drawableRight = iconForm.drawable
-          drawableRightRes = iconForm.drawableRes
+        IconGravity.RIGHT, IconGravity.END -> {
+          drawableEnd = iconForm.drawable
+          drawableEndRes = iconForm.drawableRes
         }
       }
     }
@@ -92,16 +93,16 @@ internal fun TextView.applyDrawable(vectorTextViewParams: VectorTextViewParams) 
     ?: vectorTextViewParams.widthRes?.let { context.resources.getDimensionPixelSize(it) }
     ?: vectorTextViewParams.squareSizeRes?.let { context.resources.getDimensionPixelSize(it) }
 
-  val drawableLeft: Drawable? =
+  val drawableStart: Drawable? =
     (
-      vectorTextViewParams.drawableLeft ?: vectorTextViewParams.drawableLeftRes?.let {
+      vectorTextViewParams.drawableStart ?: vectorTextViewParams.drawableStartRes?.let {
         AppCompatResources.getDrawable(context, it)
       }
       )?.resize(context, width, height)?.tint(vectorTextViewParams.tintColor)
 
-  val drawableRight: Drawable? =
+  val drawableEnd: Drawable? =
     (
-      vectorTextViewParams.drawableRight ?: vectorTextViewParams.drawableRightRes?.let {
+      vectorTextViewParams.drawableEnd ?: vectorTextViewParams.drawableEndRes?.let {
         AppCompatResources.getDrawable(context, it)
       }
       )?.resize(context, width, height)?.tint(vectorTextViewParams.tintColor)
@@ -120,7 +121,17 @@ internal fun TextView.applyDrawable(vectorTextViewParams: VectorTextViewParams) 
       }
       )?.resize(context, width, height)?.tint(vectorTextViewParams.tintColor)
 
-  setCompoundDrawablesWithIntrinsicBounds(drawableLeft, drawableTop, drawableRight, drawableBottom)
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+    setCompoundDrawablesRelativeWithIntrinsicBounds(
+      drawableStart, drawableTop, drawableEnd,
+      drawableBottom
+    )
+  } else {
+    setCompoundDrawablesWithIntrinsicBounds(
+      drawableStart, drawableTop, drawableEnd,
+      drawableBottom
+    )
+  }
 
   vectorTextViewParams.compoundDrawablePadding?.let { compoundDrawablePadding = it }
     ?: vectorTextViewParams.compoundDrawablePaddingRes?.let {

--- a/balloon/src/main/java/com/skydoves/balloon/vectortext/VectorTextView.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/vectortext/VectorTextView.kt
@@ -43,12 +43,12 @@ class VectorTextView @JvmOverloads constructor(
     if (attrs != null) {
       val attributeArray = context.obtainStyledAttributes(attrs, R.styleable.VectorTextView)
       drawableTextViewParams = VectorTextViewParams(
-        drawableLeftRes = attributeArray.getResourceId(
-          R.styleable.VectorTextView_drawableLeft,
+        drawableStartRes = attributeArray.getResourceId(
+          R.styleable.VectorTextView_drawableStart,
           NO_INT_VALUE
         ).takeIfNotNoIntValue(),
-        drawableRightRes = attributeArray.getResourceId(
-          R.styleable.VectorTextView_drawableRight,
+        drawableEndRes = attributeArray.getResourceId(
+          R.styleable.VectorTextView_drawableEnd,
           NO_INT_VALUE
         ).takeIfNotNoIntValue(),
         drawableBottomRes = attributeArray.getResourceId(

--- a/balloon/src/main/java/com/skydoves/balloon/vectortext/VectorTextViewParams.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/vectortext/VectorTextViewParams.kt
@@ -23,12 +23,12 @@ import androidx.annotation.Px
 
 /** VectorTextViewParams is a collection of [VectorTextView]'s parameters. */
 data class VectorTextViewParams(
-  var drawableLeftRes: Int? = null,
-  var drawableRightRes: Int? = null,
+  var drawableStartRes: Int? = null,
+  var drawableEndRes: Int? = null,
   var drawableBottomRes: Int? = null,
   var drawableTopRes: Int? = null,
-  var drawableLeft: Drawable? = null,
-  var drawableRight: Drawable? = null,
+  var drawableStart: Drawable? = null,
+  var drawableEnd: Drawable? = null,
   var drawableBottom: Drawable? = null,
   var drawableTop: Drawable? = null,
   @Px val compoundDrawablePadding: Int? = null,

--- a/balloon/src/main/res/values/attrs.xml
+++ b/balloon/src/main/res/values/attrs.xml
@@ -15,8 +15,8 @@
 -->
 <resources>
   <declare-styleable name="VectorTextView">
-    <attr name="drawableLeft" format="reference" />
-    <attr name="drawableRight" format="reference" />
+    <attr name="drawableStart" format="reference" />
+    <attr name="drawableEnd" format="reference" />
     <attr name="drawableTop" format="reference" />
     <attr name="drawableBottom" format="reference" />
     <attr name="drawablePadding" format="dimension" />


### PR DESCRIPTION
### Overview
To support RTL about the icon gravity, the previous enum type of the `IconGravity.LEFT` and `IconGravity.RIGHT` will be deprecated.
And we can use a new `IconGravity.START` and `IconGravity.END`.