### PR TITLE
Fix: min height size of the TextView

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -76,6 +76,7 @@ import com.skydoves.balloon.extensions.dimen
 import com.skydoves.balloon.extensions.dimenPixel
 import com.skydoves.balloon.extensions.displaySize
 import com.skydoves.balloon.extensions.dp2Px
+import com.skydoves.balloon.extensions.getHeight
 import com.skydoves.balloon.extensions.getStatusBarHeight
 import com.skydoves.balloon.extensions.getViewPointOnScreen
 import com.skydoves.balloon.extensions.isFinishing
@@ -1023,6 +1024,11 @@ class Balloon(
         View.MeasureSpec.makeMeasureSpec(context.displaySize().y, View.MeasureSpec.UNSPECIFIED)
       measure(widthSpec, heightSpec)
       maxWidth = getMeasuredTextWidth(measuredWidth, rootView)
+      if (textView.compoundDrawables[0] != null || textView.compoundDrawables[2] != null) {
+        textView.minHeight = textView.compoundDrawables[0].getHeight().coerceAtLeast(
+          textView.compoundDrawables[2].getHeight()
+        )
+      }
     }
   }
 

--- a/balloon/src/main/java/com/skydoves/balloon/extensions/DrawableExtension.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/extensions/DrawableExtension.kt
@@ -43,3 +43,8 @@ internal fun Drawable.resize(context: Context, @Px width: Int?, @Px height: Int?
     draw(canvas)
     BitmapDrawable(context.resources, bitmap)
   } else this
+
+/** returns intrinsic height size of a drawable. */
+internal fun Drawable?.getHeight(): Int {
+  return this?.intrinsicHeight ?: 0
+}


### PR DESCRIPTION
## Overview
Ensures the minimum height size of the TextView for the compound drawable. #171 