### PR TITLE
Add minimum and maximum ratio for the Balloon

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1225,7 +1225,7 @@ class Balloon(
         (displayWidth * builder.widthRatio).toInt() - spaces
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
         val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt())
+        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt() - spaces, (displayWidth * max).toInt() - spaces)
       }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1225,7 +1225,7 @@ class Balloon(
         (displayWidth * builder.widthRatio).toInt() - spaces
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
         val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt() - spaces, (displayWidth * max).toInt() - spaces)
+        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt()) - spaces
       }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1223,6 +1223,10 @@ class Balloon(
     return when {
       builder.widthRatio != NO_Float_VALUE ->
         (displayWidth * builder.widthRatio).toInt() - spaces
+      builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
+        val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
+        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt())
+      }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces
       else -> measuredWidth.coerceAtMost(maxTextWidth)

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -302,7 +302,7 @@ class Balloon(
   }
 
   /**
-   * Calculate the color at arrow position from ballonCard. The color is then set as a foreground to the arrow.
+   * Calculate the color at arrow position from balloonCard. The color is then set as a foreground to the arrow.
    *
    * @param imageView the arrow imageview containing the drawable.
    * @param x x position of the point where the middle of the arrow is connected to the balloon

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1164,6 +1164,10 @@ class Balloon(
     return when {
       builder.widthRatio != NO_Float_VALUE ->
         (displayWidth * builder.widthRatio).toInt()
+      builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
+        val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
+        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt())
+      }
       builder.width != BalloonSizeSpec.WRAP -> builder.width.coerceAtMost(displayWidth)
       else -> binding.root.measuredWidth.coerceIn(builder.minWidth, builder.maxWidth)
     }
@@ -1277,6 +1281,14 @@ class Balloon(
     @JvmField @FloatRange(from = 0.0, to = 1.0)
     @set:JvmSynthetic
     var widthRatio: Float = NO_Float_VALUE
+
+    @JvmField @FloatRange(from = 0.0, to = 1.0)
+    @set:JvmSynthetic
+    var minWidthRatio: Float = NO_Float_VALUE
+
+    @JvmField @FloatRange(from = 0.0, to = 1.0)
+    @set:JvmSynthetic
+    var maxWidthRatio: Float = NO_Float_VALUE
 
     @JvmField @Px
     @set:JvmSynthetic
@@ -1657,6 +1669,16 @@ class Balloon(
     fun setWidthRatio(
       @FloatRange(from = 0.0, to = 1.0) value: Float
     ): Builder = apply { this.widthRatio = value }
+
+    /** sets the minimum width size by the display screen size ratio. */
+    fun setMinWidthRatio(
+      @FloatRange(from = 0.0, to = 1.0) value: Float
+    ): Builder = apply { this.minWidthRatio = value }
+
+    /** sets the maximum width size by the display screen size ratio. */
+    fun setMaxWidthRatio(
+      @FloatRange(from = 0.0, to = 1.0) value: Float
+    ): Builder = apply { this.maxWidthRatio = value }
 
     /** sets the height size. */
     fun setHeight(@Dp value: Int): Builder = apply {


### PR DESCRIPTION
Hope everything is good :) Got some more additions I would like to add. These additions makes it possible to add a min and max ratio, which works just like the min and max for pixels but with ratio instead. I also fixed so it should work with the new text measuring  implementation. 
