### PR TITLE
Bug fix where wrong reference were used in getMeasuredTextWidth

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1229,7 +1229,10 @@ class Balloon(
         (displayWidth * builder.widthRatio).toInt() - spaces
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
         val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt()) - spaces
+        measuredWidth.coerceIn(
+          (displayWidth * builder.minWidthRatio).toInt(),
+          (displayWidth * max).toInt()
+        ) - spaces
       }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces


### PR DESCRIPTION
Hi again, I found a bug in my addition of min and max ratio where I used the measuredWidth from the binding instead of the parameter passed to the getMeasuredTextWidth function. That went right past my testing and just noticed it when I forgot to add a minWidthRatio. Sorry for this! 