### PR TITLE
fixes drawing the overlay padding rectangle

### DIFF
--- a/app/src/main/java/com/skydoves/balloondemo/factory/EditBalloonFactory.kt
+++ b/app/src/main/java/com/skydoves/balloondemo/factory/EditBalloonFactory.kt
@@ -47,8 +47,8 @@ class EditBalloonFactory : Balloon.Factory() {
       .setBalloonAnimation(BalloonAnimation.ELASTIC)
       .setIsVisibleOverlay(true)
       .setOverlayColorResource(R.color.overlay)
-      .setOverlayPadding(6f)
-      .setOverlayShape(BalloonOverlayRoundRect(12f, 12f))
+      .setOverlayPaddingResource(R.dimen.editBalloonOverlayPadding)
+      .setOverlayShape(BalloonOverlayRoundRect(R.dimen.editBalloonOverlayRadius, R.dimen.editBalloonOverlayRadius))
       .setLifecycleOwner(lifecycle)
       .setDismissWhenClicked(true)
       .setOnBalloonDismissListener {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <dimen name="textSize">15sp</dimen>
+  <dimen name="editBalloonOverlayPadding">6dp</dimen>
+  <dimen name="editBalloonOverlayRadius">11dp</dimen>
 </resources>

--- a/balloon/src/main/java/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
@@ -153,7 +153,7 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
     paddingColorPaint.apply {
       color = overlayPaddingColor
       style = Paint.Style.STROKE
-      strokeWidth = overlayPadding * 2
+      strokeWidth = overlayPadding
     }
 
     anchorView?.let { anchor ->
@@ -173,19 +173,29 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
         rect.bottom + overlayPadding
       )
 
+      val halfOfOverlayPadding = overlayPadding / 2
+      val anchorPaddingRect = RectF(anchorRect).apply {
+        inset(halfOfOverlayPadding, halfOfOverlayPadding)
+      }
+
       when (val overlay = balloonOverlayShape) {
         is BalloonOverlayRect -> {
           canvas.drawRect(anchorRect, paint)
-          canvas.drawRect(anchorRect, paddingColorPaint)
+          canvas.drawRect(anchorPaddingRect, paddingColorPaint)
         }
         is BalloonOverlayOval -> {
           canvas.drawOval(anchorRect, paint)
-          canvas.drawOval(anchorRect, paddingColorPaint)
+          canvas.drawOval(anchorPaddingRect, paddingColorPaint)
         }
         is BalloonOverlayCircle -> {
           overlay.radius?.let { radius ->
             canvas.drawCircle(anchorRect.centerX(), anchorRect.centerY(), radius, paint)
-            canvas.drawCircle(anchorRect.centerX(), anchorRect.centerY(), radius, paddingColorPaint)
+            canvas.drawCircle(
+              anchorPaddingRect.centerX(),
+              anchorPaddingRect.centerY(),
+              radius - halfOfOverlayPadding,
+              paddingColorPaint
+            )
           }
           overlay.radiusRes?.let { radiusRes ->
             canvas.drawCircle(
@@ -193,7 +203,7 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
               paint
             )
             canvas.drawCircle(
-              anchorRect.centerX(), anchorRect.centerY(), context.dimen(radiusRes),
+              anchorPaddingRect.centerX(), anchorPaddingRect.centerY(), context.dimen(radiusRes) - halfOfOverlayPadding,
               paddingColorPaint
             )
           }
@@ -201,7 +211,12 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
         is BalloonOverlayRoundRect -> {
           overlay.radiusPair?.let { radiusPair ->
             canvas.drawRoundRect(anchorRect, radiusPair.first, radiusPair.second, paint)
-            canvas.drawRoundRect(anchorRect, radiusPair.first, radiusPair.second, paddingColorPaint)
+            canvas.drawRoundRect(
+              anchorPaddingRect,
+              radiusPair.first - halfOfOverlayPadding,
+              radiusPair.second - halfOfOverlayPadding,
+              paddingColorPaint
+            )
           }
           overlay.radiusResPair?.let { radiusResPair ->
             canvas.drawRoundRect(
@@ -209,8 +224,8 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
               context.dimen(radiusResPair.second), paint
             )
             canvas.drawRoundRect(
-              anchorRect, context.dimen(radiusResPair.first),
-              context.dimen(radiusResPair.second), paddingColorPaint
+              anchorPaddingRect, context.dimen(radiusResPair.first) - halfOfOverlayPadding,
+              context.dimen(radiusResPair.second) - halfOfOverlayPadding, paddingColorPaint
             )
           }
         }


### PR DESCRIPTION
The implementation for the feature request https://github.com/skydoves/Balloon/issues/213 (PR https://github.com/skydoves/Balloon/pull/221) exhibits an issue if a semitransparent color is used for overlay padding:

![Untitled](https://user-images.githubusercontent.com/198951/127753867-721e3716-ff8a-4153-b46a-42d7d088dac2.png)

This is because Paint stoke is always centered, so half of the stroke width is drown inside and the second half is drown outside.

The goal is to use only the inside half of the stroke (which is not directly supported by Android). This PR emulates inner stroke for the padding, thus not overstepping the actual padding:

* No custom color for overlay padding:

![device-2021-07-31-235608_cr](https://user-images.githubusercontent.com/198951/127754028-7115a622-2d0a-437b-9a41-ecd0562aafe6.png)

* Opaque custom color for overlay padding:

![device-2021-07-31-235444_cr](https://user-images.githubusercontent.com/198951/127754063-fcf38730-c6e1-420c-a361-7d92dbc4e1d3.png)

* Semitransparent color for overlay padding:

![device-2021-08-01-000506_cr](https://user-images.githubusercontent.com/198951/127754074-c601afa4-3194-423a-bbae-87cc4caf86ef.png)


### Types of changes

This is a fix for the PR https://github.com/skydoves/Balloon/pull/221.