### PR TITLE
Fix min max ratio inconsistency in getMeasuredTextWidth

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1172,8 +1172,11 @@ class Balloon(
       builder.widthRatio != NO_Float_VALUE ->
         (displayWidth * builder.widthRatio).toInt()
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
-        val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        binding.root.measuredWidth.coerceIn((displayWidth * builder.minWidthRatio).toInt(), (displayWidth * max).toInt())
+        val maxWidthRatio = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
+        binding.root.measuredWidth.coerceIn(
+          (displayWidth * builder.minWidthRatio).toInt(),
+          (displayWidth * maxWidthRatio).toInt()
+        )
       }
       builder.width != BalloonSizeSpec.WRAP -> builder.width.coerceAtMost(displayWidth)
       else -> binding.root.measuredWidth.coerceIn(builder.minWidth, builder.maxWidth)
@@ -1229,8 +1232,8 @@ class Balloon(
       builder.widthRatio != NO_Float_VALUE ->
         (displayWidth * builder.widthRatio).toInt() - spaces
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
-        val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        measuredWidth.coerceAtMost((displayWidth * max).toInt() - spaces)
+        val maxWidthRatio = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
+        measuredWidth.coerceAtMost((displayWidth * maxWidthRatio).toInt() - spaces)
       }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1230,10 +1230,7 @@ class Balloon(
         (displayWidth * builder.widthRatio).toInt() - spaces
       builder.minWidthRatio != NO_Float_VALUE || builder.maxWidthRatio != NO_Float_VALUE -> {
         val max = if (builder.maxWidthRatio != NO_Float_VALUE) builder.maxWidthRatio else 1f
-        measuredWidth.coerceIn(
-          (displayWidth * builder.minWidthRatio).toInt(),
-          (displayWidth * max).toInt()
-        ) - spaces
+        measuredWidth.coerceAtMost((displayWidth * max).toInt() - spaces)
       }
       builder.width != BalloonSizeSpec.WRAP && builder.width <= displayWidth ->
         builder.width - spaces

--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1226,7 +1226,7 @@ class Balloon(
     val spaces = rootView.paddingLeft + rootView.paddingRight + if (builder.iconDrawable != null) {
       builder.iconWidth + builder.iconSpace
     } else 0 + builder.marginRight + builder.marginLeft + (builder.arrowSize * 2)
-    val maxTextWidth = displayWidth - spaces
+    val maxTextWidth = builder.maxWidth - spaces
 
     return when {
       builder.widthRatio != NO_Float_VALUE ->


### PR DESCRIPTION
Hi again, I found an inconsistency in the code that I wrote in #214. In getMeasuredTextWidth I used _coerceIn_ instead of _coerceAtMost_ which is more consistent with how the other cases is written. The subtraction of spaces outside of the _coerceIn_-function gave some unwanted behavior where the dialog would be smaller than intended