### PR TITLE
Fixes #228 "Overlay is not redrawn on Balloon.update(anchor) call"

### DIFF
--- a/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/Balloon.kt
@@ -1018,6 +1018,9 @@ class Balloon(
   fun update(anchor: View, xOff: Int = 0, yOff: Int = 0) {
     update(anchor = anchor) {
       this.bodyWindow.update(anchor, xOff, yOff, getMeasuredWidth(), getMeasuredHeight())
+      if (builder.isVisibleOverlay) {
+        overlayBinding.balloonOverlayView.forceInvalidate()
+      }
     }
   }
 

--- a/balloon/src/main/java/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
+++ b/balloon/src/main/java/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
@@ -115,6 +115,11 @@ class BalloonAnchorOverlayView @JvmOverloads constructor(
     }
   }
 
+  fun forceInvalidate() {
+    invalidated = true
+    invalidate()
+  }
+
   override fun dispatchDraw(canvas: Canvas?) {
     if (invalidated || bitmap == null || bitmap?.isRecycled == true) {
       prepareBitmap()


### PR DESCRIPTION
This is a bugfix for #228 