### PR TITLE
Downgrade JVM target version to 1.8 of the balloon module

### DIFF
--- a/balloon/build.gradle
+++ b/balloon/build.gradle
@@ -32,11 +32,11 @@ android {
         viewBinding true
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "1.8"
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
## Guidelines
Downgrade JVM target version to 1.8 of the balloon module.
