### PR TITLE
Add public.xml to the resources

### DIFF
--- a/balloon/src/main/res/values/public.xml
+++ b/balloon/src/main/res/values/public.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <public name="balloon_layout_body" type="layout" />
+  <public name="balloon_layout_overlay" type="layout" />
+</resources>


### PR DESCRIPTION
## Overview
Add `public.xml` to the resources to prevent access to internal resources.