### PR TITLE
Bump AGP to 7.2.0 and kotlin to 1.6.21

### DIFF
--- a/buildSrc/src/main/kotlin/com/skydoves/balloon/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/balloon/Dependencies.kt
@@ -1,11 +1,11 @@
 package com.skydoves.balloon
 
 object Versions {
-  internal const val ANDROID_GRADLE_PLUGIN = "7.1.2"
+  internal const val ANDROID_GRADLE_PLUGIN = "7.2.0"
   internal const val ANDROID_GRADLE_SPOTLESS = "6.3.0"
   internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-  internal const val KOTLIN = "1.6.10"
-  internal const val KOTLIN_GRADLE_DOKKA = "1.6.10"
+  internal const val KOTLIN = "1.6.21"
+  internal const val KOTLIN_GRADLE_DOKKA = "1.6.21"
   internal const val KOTLIN_BINARY_VALIDATOR = "0.8.0"
 
   internal const val APPCOMPAT = "1.4.0"


### PR DESCRIPTION
## Guidelines
Bump AGP to 7.2.0 and kotlin to 1.6.21.