### PR TITLE
Fix getting resource id from the drawable tint color

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/vectortext/VectorTextView.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/vectortext/VectorTextView.kt
@@ -63,7 +63,7 @@ public class VectorTextView @JvmOverloads constructor(
           R.styleable.VectorTextView_balloon_drawablePadding,
           NO_INT_VALUE
         ).takeIfNotNoIntValue(),
-        tintColor = attributeArray.getResourceId(
+        tintColor = attributeArray.getColor(
           R.styleable.VectorTextView_balloon_drawableTintColor,
           NO_INT_VALUE
         ).takeIfNotNoIntValue(),


### PR DESCRIPTION
### 🎯 Goal
Fix getting resource id from the drawable tint color.
