### PR TITLE
A11y fix: remove clickable hint from Talkback description when no click listener is set on Balloon

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1215,9 +1215,11 @@ public class Balloon private constructor(
 
   /** sets a [OnBalloonClickListener] to the popup. */
   public fun setOnBalloonClickListener(onBalloonClickListener: OnBalloonClickListener?) {
-    this.binding.balloonWrapper.setOnClickListener {
-      onBalloonClickListener?.onBalloonClick(it)
-      if (builder.dismissWhenClicked) dismiss()
+    if (onBalloonClickListener != null || builder.dismissWhenClicked) {
+      this.binding.balloonWrapper.setOnClickListener {
+        onBalloonClickListener?.onBalloonClick(it)
+        if (builder.dismissWhenClicked) dismiss()
+      }
     }
   }
 

--- a/balloon/src/main/res/layout/balloon_layout_body.xml
+++ b/balloon/src/main/res/layout/balloon_layout_body.xml
@@ -25,6 +25,7 @@
     android:id="@+id/balloon_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:focusable="true"
     tools:ignore="UselessParent">
 
     <FrameLayout
@@ -50,6 +51,7 @@
           android:layout_gravity="center_vertical"
           android:gravity="center"
           android:textColor="@android:color/white"
+          android:focusable="false"
           tools:text="@tools:sample/lorem" />
 
       </com.skydoves.balloon.radius.RadiusLayout>


### PR DESCRIPTION
### 🎯 Goal
The goal of this PR is to improve the correctness of screen reader hints for Balloons that do not have a click listener set (via `Balloon::setOnBalloonClickListener`).

Currently, Talkback will incorrectly say "double-tap to activate" for these Balloons. This change removes that part of the Talkback description without affecting the rest of it.

### 🛠 Implementation details
Currently `setOnBalloonClickListener()` always sets a "wrapper/parent" click listener on the Balloon, even when the click listener argument is `null`. Talkback incorrectly infers from this that the Balloon is clickable, despite it possibly being a no-op click listener.

This change only sets the parent click listener when clicking would likely have some noticeable effect. More specifically, if the `onBalloonClickListener` argument is non-null or if `builder.dismissWhenClicked` is true.

`android:focusable="true"` was set on the balloon wrapper `FrameLayout` in order to maintain the existing Talkback behavior of reading out the text contents of the Balloon.

### ✍️ Explain examples
In the example below, tapping the highlighted balloon with Talkback on would currently read out:
**"skydoves. Love coffee, music, magic tricks and writing poems. Double-tap to activate."**

After this change:
**"skydoves. Love coffee, music, magic tricks and writing poems."**

<img src="https://user-images.githubusercontent.com/101530504/211226393-1807f90a-e68a-4525-858d-ea03b74c606b.png" width="320" />

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```
✅ 

Please let me know if you have any requests for improvement for this to be acceptable to merge.
