### PR TITLE
Set arrow orientation rule as fixed when user manually set the arrow the arrow orientation

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -2427,6 +2427,7 @@ public class Balloon private constructor(
     /** sets the arrow orientation using [ArrowOrientation]. */
     public fun setArrowOrientation(value: ArrowOrientation): Builder = apply {
       this.arrowOrientation = value
+      this.arrowOrientationRules = ArrowOrientationRules.ALIGN_FIXED
     }
 
     /**


### PR DESCRIPTION
Set arrow orientation rule as fixed when user manually set the arrow the arrow orientation.