### PR TITLE
Add a letter spacing option for Balloon and TextForm.

### DIFF
--- a/balloon/api/balloon.api
+++ b/balloon/api/balloon.api
@@ -282,8 +282,8 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun getTextForm ()Lcom/skydoves/balloon/TextForm;
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
-	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextLetterSpacing ()Ljava/lang/Float;
+	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextTypeface ()I
 	public final fun getTextTypefaceObject ()Landroid/graphics/Typeface;
@@ -537,12 +537,12 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final synthetic fun setTextGravity (I)V
 	public final fun setTextIsHtml (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setTextIsHtml (Z)V
-	public final fun setTextLineSpacing (F)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextLetterSpacing (F)Lcom/skydoves/balloon/Balloon$Builder;
-	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
 	public final synthetic fun setTextLetterSpacing (Ljava/lang/Float;)V
-	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextLetterSpacingResource (I)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setTextLineSpacing (F)Lcom/skydoves/balloon/Balloon$Builder;
+	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
+	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextSize (F)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setTextSize (F)V
@@ -828,8 +828,8 @@ public final class com/skydoves/balloon/TextForm {
 	public final fun getTextColor ()I
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
-	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextLetterSpacing ()Ljava/lang/Float;
+	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextStyle ()I
 	public final fun getTextTypeface ()Landroid/graphics/Typeface;
@@ -844,8 +844,8 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public final fun getTextColor ()I
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
-	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextLetterSpacing ()Ljava/lang/Float;
+	public final fun getTextLineSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextTypeface ()I
 	public final fun getTextTypefaceObject ()Landroid/graphics/Typeface;
@@ -860,12 +860,12 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public final synthetic fun setTextGravity (I)V
 	public final fun setTextIsHtml (Z)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setTextIsHtml (Z)V
-	public final fun setTextLineSpacing (Ljava/lang/Float;)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextLetterSpacing (Ljava/lang/Float;)Lcom/skydoves/balloon/TextForm$Builder;
-	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
 	public final synthetic fun setTextLetterSpacing (Ljava/lang/Float;)V
-	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextLetterSpacingResource (I)Lcom/skydoves/balloon/TextForm$Builder;
+	public final fun setTextLineSpacing (Ljava/lang/Float;)Lcom/skydoves/balloon/TextForm$Builder;
+	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
+	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextResource (I)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextSize (F)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setTextSize (F)V

--- a/balloon/api/balloon.api
+++ b/balloon/api/balloon.api
@@ -283,6 +283,7 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
 	public final fun getTextLineSpacing ()Ljava/lang/Float;
+	public final fun getTextLetterSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextTypeface ()I
 	public final fun getTextTypefaceObject ()Landroid/graphics/Typeface;
@@ -537,8 +538,11 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun setTextIsHtml (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setTextIsHtml (Z)V
 	public final fun setTextLineSpacing (F)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setTextLetterSpacing (F)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
+	public final synthetic fun setTextLetterSpacing (Ljava/lang/Float;)V
 	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setTextLetterSpacingResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setTextSize (F)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setTextSize (F)V
@@ -825,6 +829,7 @@ public final class com/skydoves/balloon/TextForm {
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
 	public final fun getTextLineSpacing ()Ljava/lang/Float;
+	public final fun getTextLetterSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextStyle ()I
 	public final fun getTextTypeface ()Landroid/graphics/Typeface;
@@ -840,6 +845,7 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public final fun getTextGravity ()I
 	public final fun getTextIsHtml ()Z
 	public final fun getTextLineSpacing ()Ljava/lang/Float;
+	public final fun getTextLetterSpacing ()Ljava/lang/Float;
 	public final fun getTextSize ()F
 	public final fun getTextTypeface ()I
 	public final fun getTextTypefaceObject ()Landroid/graphics/Typeface;
@@ -855,8 +861,11 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public final fun setTextIsHtml (Z)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setTextIsHtml (Z)V
 	public final fun setTextLineSpacing (Ljava/lang/Float;)Lcom/skydoves/balloon/TextForm$Builder;
+	public final fun setTextLetterSpacing (Ljava/lang/Float;)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setTextLineSpacing (Ljava/lang/Float;)V
+	public final synthetic fun setTextLetterSpacing (Ljava/lang/Float;)V
 	public final fun setTextLineSpacingResource (I)Lcom/skydoves/balloon/TextForm$Builder;
+	public final fun setTextLetterSpacingResource (I)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextResource (I)Lcom/skydoves/balloon/TextForm$Builder;
 	public final fun setTextSize (F)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setTextSize (F)V

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -615,6 +615,7 @@ public class Balloon private constructor(
           setTextTypeface(builder.textTypeface)
           setTextTypeface(builder.textTypefaceObject)
           setTextLineSpacing(builder.textLineSpacing)
+          setTextLetterSpacing(builder.textLetterSpacing)
           setMovementMethod(builder.movementMethod)
         },
       )
@@ -1948,6 +1949,9 @@ public class Balloon private constructor(
     public var textLineSpacing: Float? = null
 
     @set:JvmSynthetic
+    public var textLetterSpacing: Float? = null
+
+    @set:JvmSynthetic
     public var textGravity: Int = Gravity.CENTER
 
     @set:JvmSynthetic
@@ -2588,9 +2592,18 @@ public class Balloon private constructor(
     public fun setTextLineSpacing(@Dp value: Float): Builder =
       apply { this.textLineSpacing = value }
 
+    /** sets the letter spacing value of the text. */
+    public fun setTextLetterSpacing(@Dp value: Float): Builder =
+      apply { this.textLetterSpacing = value }
+
     /** sets the line spacing value resource of the text. */
     public fun setTextLineSpacingResource(@DimenRes value: Int): Builder = apply {
       this.textLineSpacing = context.dimen(value)
+    }
+
+    /** sets the letter spacing value resource of the text. */
+    public fun setTextLetterSpacingResource(@DimenRes value: Int): Builder = apply {
+      this.textLetterSpacing = context.dimen(value)
     }
 
     /**

--- a/balloon/src/main/kotlin/com/skydoves/balloon/TextForm.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/TextForm.kt
@@ -74,6 +74,8 @@ public class TextForm private constructor(
 
   public val textLineSpacing: Float? = builder.textLineSpacing
 
+  public val textLetterSpacing: Float? = builder.textLetterSpacing
+
   public val textGravity: Int = builder.textGravity
 
   /** Builder class for [TextForm]. */
@@ -104,6 +106,9 @@ public class TextForm private constructor(
 
     @set:JvmSynthetic
     public var textLineSpacing: Float? = null
+
+    @set:JvmSynthetic
+    public var textLetterSpacing: Float? = null
 
     @set:JvmSynthetic
     public var textGravity: Int = Gravity.CENTER
@@ -144,9 +149,18 @@ public class TextForm private constructor(
     public fun setTextLineSpacing(@Dp value: Float?): Builder =
       apply { this.textLineSpacing = value }
 
+    /** sets the letter spacing value of the text. */
+    public fun setTextLetterSpacing(@Dp value: Float?): Builder =
+      apply { this.textLetterSpacing = value }
+
     /** sets the line spacing value resource of the text. */
     public fun setTextLineSpacingResource(@DimenRes value: Int): Builder = apply {
       this.textLineSpacing = context.dimen(value)
+    }
+
+    /** sets the letter spacing value resource of the text. */
+    public fun setTextLetterSpacingResource(@DimenRes value: Int): Builder = apply {
+      this.textLetterSpacing = context.dimen(value)
     }
 
     /** sets the [Typeface] of the text. */

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/TextViewExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/TextViewExtension.kt
@@ -42,6 +42,7 @@ internal fun TextView.applyTextForm(textForm: TextForm) {
   gravity = textForm.textGravity
   setTextColor(textForm.textColor)
   textForm.textLineSpacing?.let { setLineSpacing(it, 1.0f) }
+  textForm.textLetterSpacing?.let { letterSpacing = it }
   textForm.textTypeface?.let { typeface = it } ?: setTypeface(typeface, textForm.textStyle)
   textForm.movementMethod?.let { movementMethod = it }
 }


### PR DESCRIPTION
### 🎯 Goal
Add letter spacing to the API.

### 🛠 Implementation details
All changes are essentially a copy of the line spacing code, changed to letter spacing.

### ✍️ Explain examples
Simply adding a `.setTextLetterSpacing(0.1f)` can result in improved readability in text:

![image](https://github.com/skydoves/Balloon/assets/1585923/51dfc1cb-9ee4-44e5-96d6-3517fb37d7c3)

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

:no_entry: — This fails already in the main library itself

Then dump binary APIs of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

```bash
./gradlew apiDump
```

:heavy_check_mark: 

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
