### PR TITLE
Remove offset on popup for Compose balloons

### DIFF
--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/Balloon.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/Balloon.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -113,10 +112,6 @@ public fun Balloon(
     val paddingEnd =
       remember { with(density) { (builder.paddingRight + builder.marginRight).toDp() } }
     Popup(
-      offset = IntOffset(
-        Int.MAX_VALUE,
-        Int.MAX_VALUE,
-      ),
       properties = PopupProperties(
         dismissOnBackPress = false,
         dismissOnClickOutside = false,


### PR DESCRIPTION
### 🎯 Goal
Fix the device restart that occurs on devices running Android 9 and below when showing a Balloon with Compose content.

Fixes #528 and #531

### 🛠 Implementation details
For some reason, passing an offset with Int.MAX_VALUE to the Compose Popup causes the device to become unresponsive and restart on older Android versions. Removing the offset from the popup doesn't seem to affect the position of the final balloon, so removing the offset seems to be a safe fix.