### PR TITLE
Touching outside the balloonWrapper should dismiss the Balloon(PopupWindow)

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1602,6 +1602,15 @@ public class Balloon private constructor(
             onBalloonOutsideTouchListener?.onBalloonOutsideTouch(view, event)
             return true
           }
+          if (event.action == MotionEvent.ACTION_UP) {
+            if (binding.balloonWrapper.getViewPointOnScreen().x > event.rawX) {
+              if (builder.dismissWhenTouchOutside) {
+                this@Balloon.dismiss()
+              }
+              onBalloonOutsideTouchListener?.onBalloonOutsideTouch(view, event)
+              return true
+            }
+          }
           return false
         }
       },

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1604,7 +1604,10 @@ public class Balloon private constructor(
           }
           if (event.action == MotionEvent.ACTION_UP) {
             if (binding.balloonWrapper.getViewPointOnScreen().x > event.rawX ||
-              binding.balloonWrapper.getViewPointOnScreen().x + binding.balloonWrapper.measuredWidth < event.rawX
+              (
+                binding.balloonWrapper.getViewPointOnScreen().x +
+                  binding.balloonWrapper.measuredWidth
+                ) < event.rawX
             ) {
               if (builder.dismissWhenTouchOutside) {
                 this@Balloon.dismiss()

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1603,7 +1603,9 @@ public class Balloon private constructor(
             return true
           }
           if (event.action == MotionEvent.ACTION_UP) {
-            if (binding.balloonWrapper.getViewPointOnScreen().x > event.rawX) {
+            if (binding.balloonWrapper.getViewPointOnScreen().x > event.rawX ||
+              binding.balloonWrapper.getViewPointOnScreen().x + binding.balloonWrapper.measuredWidth < event.rawX
+            ) {
               if (builder.dismissWhenTouchOutside) {
                 this@Balloon.dismiss()
               }


### PR DESCRIPTION
### 🎯 Goal
Touching outside the balloonWrapper should dismiss the PopupWindow. This should help with the issue: [486](https://github.com/skydoves/Balloon/issues/486). This is not the finished product but a work in progress.

### 🛠 Implementation details
`if (event.action == MotionEvent.ACTION_UP) {`
`            if(binding.balloonWrapper.getViewPointOnScreen().x > event.rawX) {`
`              if (builder.dismissWhenTouchOutside) {`
`                this@Balloon.dismiss()`
`              }`
`              onBalloonOutsideTouchListener?.onBalloonOutsideTouch(view, event)`
`              return true`
`            }`
`          }`

If the user touches to the left of the balloonWrapper Balloon will be dismissed. This solves the issue for the left margin, but other margins should also be considered. The code is not fully polished therefore the way the coordinates are accessed might change as well as the actions that cause Balloon to be dismissed.

### Further Guidance
I am not sure if this should be a draft pull request?
This will need further review and guidance to decide how to solve this issue or maybe this is the expected behaviour and should not be considered an issue.