### PR TITLE
Support detached Fragments by removing references to the Activity

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -97,7 +97,6 @@ import com.skydoves.balloon.extensions.getSumOfIntrinsicWidth
 import com.skydoves.balloon.extensions.getViewPointOnScreen
 import com.skydoves.balloon.extensions.isAPILevelHigherThan23
 import com.skydoves.balloon.extensions.isExistHorizontalDrawable
-import com.skydoves.balloon.extensions.isFinishing
 import com.skydoves.balloon.extensions.px2Sp
 import com.skydoves.balloon.extensions.runOnAfterSDK22
 import com.skydoves.balloon.extensions.runOnAfterSDK23
@@ -908,13 +907,10 @@ public class Balloon private constructor(
       // If the balloon is already destroyed depending on the lifecycle,
       // We should not allow showing the popupWindow, it's related to `relay()` method. (#46)
       !destroyed &&
-      // We should check the current Activity is running.
-      // If the Activity is finishing, we can't attach the popupWindow to the Activity's window. (#92)
-      !context.isFinishing &&
       // We should check the contentView is already attached to the decorView or backgroundView in the popupWindow.
       // Sometimes there is a concurrency issue between show and dismiss the popupWindow. (#149)
       bodyWindow.contentView.parent == null &&
-      // we should check the anchor view is attached to the parent's window.
+      // we should check the anchor view is attached to the parent's window. (#92)
       ViewCompat.isAttachedToWindow(anchor)
   }
 

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -19,6 +19,7 @@
 package com.skydoves.balloon
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
@@ -903,15 +904,22 @@ public class Balloon private constructor(
   }
 
   private fun canShowBalloonWindow(anchor: View): Boolean {
-    return !isShowing &&
-      // If the balloon is already destroyed depending on the lifecycle,
-      // We should not allow showing the popupWindow, it's related to `relay()` method. (#46)
-      !destroyed &&
-      // We should check the contentView is already attached to the decorView or backgroundView in the popupWindow.
-      // Sometimes there is a concurrency issue between show and dismiss the popupWindow. (#149)
-      bodyWindow.contentView.parent == null &&
-      // we should check the anchor view is attached to the parent's window. (#92)
-      ViewCompat.isAttachedToWindow(anchor)
+    // If the balloon is already showing, we don't to try and show it again.
+    if (isShowing) return false
+
+    // If the balloon is already destroyed depending on the lifecycle,
+    // We should not allow showing the popupWindow, it's related to `relay()` method. (#46)
+    if (destroyed) return false
+
+    // If the Activity is finishing, we can't attach the popupWindow to the Activity's window. (#92)
+    if ((context as? Activity)?.isFinishing == true) return false
+
+    // We should check the contentView is already attached to the decorView or backgroundView in the popupWindow.
+    // Sometimes there is a concurrency issue between show and dismiss the popupWindow. (#149)
+    if (bodyWindow.contentView.parent != null) return false
+
+    // we should check the anchor view is attached to the parent's window.
+    return ViewCompat.isAttachedToWindow(anchor)
   }
 
   private fun showOverlayWindow(anchor: View, subAnchors: List<View>) {

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
@@ -16,7 +16,6 @@
 
 package com.skydoves.balloon.extensions
 
-import android.app.Activity
 import android.content.Context
 import android.graphics.drawable.Drawable
 import androidx.annotation.DimenRes
@@ -53,8 +52,3 @@ internal fun Context.contextColor(resource: Int): Int {
 internal fun Context.contextDrawable(resource: Int): Drawable? {
   return AppCompatResources.getDrawable(this, resource)
 }
-
-/** returns if an Activity is finishing or not. */
-internal val Context.isFinishing: Boolean
-  @JvmSynthetic inline get() = this is Activity && this.isFinishing
-

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
@@ -18,9 +18,7 @@ package com.skydoves.balloon.extensions
 
 import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.graphics.drawable.Drawable
-import androidx.activity.ComponentActivity
 import androidx.annotation.DimenRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
@@ -60,15 +58,3 @@ internal fun Context.contextDrawable(resource: Int): Drawable? {
 internal val Context.isFinishing: Boolean
   @JvmSynthetic inline get() = this is Activity && this.isFinishing
 
-/** returns an activity from a context. */
-@JvmSynthetic
-internal fun Context.getActivity(): ComponentActivity? {
-  var context = this
-  while (context is ContextWrapper) {
-    if (context is ComponentActivity) {
-      return context
-    }
-    context = context.baseContext
-  }
-  return null
-}

--- a/balloon/src/main/kotlin/com/skydoves/balloon/internals/FragmentBalloonLazy.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/internals/FragmentBalloonLazy.kt
@@ -53,7 +53,7 @@ internal class FragmentBalloonLazy<out T : Balloon.Factory>(
       } else {
         fragment
       }
-      val instance = factory.create(fragment.requireActivity(), lifecycle)
+      val instance = factory.create(fragment.requireContext(), lifecycle)
       cached = instance
 
       return instance

--- a/balloon/src/main/kotlin/com/skydoves/balloon/internals/ViewBalloonLazy.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/internals/ViewBalloonLazy.kt
@@ -68,7 +68,7 @@ internal class ViewBalloonLazy<out T : Balloon.Factory>(
                 } else {
                   fragment
                 }
-                instance = factory.create(fragment.requireActivity(), lifecycle)
+                instance = factory.create(fragment.requireContext(), lifecycle)
                 cached = instance
               } else {
                 throw IllegalArgumentException(


### PR DESCRIPTION
### 🎯 Goal

Previously if we create a fragment that is not yet attached to the activity and reference the balloon, this will throw an `IllegalStateException`. This is because the lazy loader requires an `Activity` even thought the implementation only requires `Context`.

This change removes all references to activities, so the balloon can be successfully attached to the anchor without needing the activity context. 

### 🛠 Implementation details

1. Update Lazy helpers to use `requireContext` instead of `requireActivity`
2. Remove unused `getActivity` method 
3. Remove unneccesary `Context.isFinishing` method because `isAttachedToWindow` should resolve issue #92 

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
