### PR TITLE
Update custom view width calculation for TextViews

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1885,7 +1885,7 @@ public class Balloon private constructor(
   }
 
   /**
-   * Measures the width of a [TextView] and set the measured with.
+   * Measures the width of a [TextView], including horizontal padding, and sets the measured width.
    * If the width of the parent XML layout is the `WRAP_CONTENT`, and the width of [TextView]
    * in the parent layout is `WRAP_CONTENT`, this method will measure the size of the width exactly.
    *
@@ -1897,12 +1897,12 @@ public class Balloon private constructor(
       if (compoundDrawablesRelative.isExistHorizontalDrawable()) {
         minHeight = compoundDrawablesRelative.getIntrinsicHeight()
         measuredTextWidth +=
-          compoundDrawablesRelative.getSumOfIntrinsicWidth() + sumOfCompoundPadding
+          compoundDrawablesRelative.getSumOfIntrinsicWidth()
       } else if (compoundDrawables.isExistHorizontalDrawable()) {
         minHeight = compoundDrawables.getIntrinsicHeight()
-        measuredTextWidth += compoundDrawables.getSumOfIntrinsicWidth() + sumOfCompoundPadding
+        measuredTextWidth += compoundDrawables.getSumOfIntrinsicWidth()
       }
-      maxWidth = getMeasuredTextWidth(measuredTextWidth, rootView)
+      maxWidth = getMeasuredTextWidth(measuredTextWidth + sumOfCompoundPadding, rootView)
     }
   }
 


### PR DESCRIPTION
# Overview

Resolved missing horizontal padding when calculating width for custom layouts.

### Details

When showing a Balloon with a custom layout, the [custom view tree is walked](https://github.com/skydoves/Balloon/blob/main/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt#L1915) and checked for instances of `TextView`.

Any `TextView` widgets, and by extension, descendants of `TextView` (e.g., `Button`), has its [text measured for calculating width](https://github.com/skydoves/Balloon/blob/main/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt#L1896).

The measurement heuristics adds horizontal padding while using compound drawables, but not otherwise. This works great when a custom layout's `TextView` has no horizontal padding, but constrains text when horizontal padding is present.

Since padding is _inside_ the bounds of the `TextView`, we would like the resulting `maxWidth` calculation to contain this extra space information to render the full text.

Here are some example screenshots showing the behavior with and without horizontal padding, before and after this PR's changes:

**Before changes with zero horizontal padding**
<img src="https://github.com/user-attachments/assets/75679a1e-ddad-4a1c-86bc-84bc4a54c2da" width="400">

**Before changes with 10dp `paddingHorizontal`**
<img src="https://github.com/user-attachments/assets/ff899fe5-dc79-4806-af30-305a03d8427e" width="400">

**After changes with 10dp `paddingHorizontal`**
<img src="https://github.com/user-attachments/assets/842b055e-0450-4fa3-8958-4e71c213f740" width="400">

-----

### Reproduction steps

1. Create a new project and surface a Balloon via:

```kotlin
    val balloon = Balloon.Builder(context)
      .setLayout(R.layout.custom_layout)
      .build()
    
    balloon.showAlignBottom(someAnchorView)
```

where `custom_layout` is:

```xml
<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
  android:layout_width="match_parent"
  android:layout_height="wrap_content">

  <TextView
    android:id="@+id/textview"
    android:layout_width="wrap_content"
    android:layout_height="wrap_content"
    android:ellipsize="end"
    android:maxLines="1"
    android:paddingHorizontal="20dp"
    android:text="Hello, there!" />

</LinearLayout>
```

<sub>Note: can also use `padingLeft`/`paddingStart` and `paddingRight`/`paddingEnd` to demonstrate the issue.</sub>

### Resolution

Add overall horizontal compound padding to TextView's `maxWidth` measurement always. Also updated the `Balloon#measureTextWidth` kdoc.

