### PR TITLE
Support auto-sized text

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,25 @@ balloon.setPaddingTop(12) // sets 12dp padding to content's top.
 ### Margin
 If the location of the balloon according to the anchor would be located at the boundaries on the screen,<br>
 the balloon will be stick to the end of the screen. In this case, we can give horizontal margins to the balloon.
+
 ```kotlin
 .setMargin(12) // sets the margin on the balloon all directions.
 .setMarginLeft(14) // sets the left margin on the balloon.
 .setMarginRight(14) // sets the right margin on the balloon.
 ```
+
+### Auto-sized text
+
+You can set auto-sized text based on the balloon's window size, specifying minimum and maximum text sizes, as shown in the example below:
+
+```kotlin
+.setTextSize(15f)
+.setMinAutoSizeTextSize(14f)
+.setMaxAutoSizeTextSize(18f)
+.setEnableAutoSized(true)
+```
+
+> Note: Ensure that the maximum auto text size is set to a value higher than the minimum auto text size.
 
 ### Arrow Composition
 We can customize the arrow on the Balloon with various methods. For more details, check out the [Balloon.Builder](https://skydoves.github.io/libraries/balloon/html/balloon/com.skydoves.balloon/-balloon/-builder/index.html).
@@ -322,9 +336,11 @@ We can customize the text on the Balloon.
 ```
 
 If your text includes HTML tags, you can render the text by enabling HTML option with `setTextIsHtml` method.
+
 ```java
 .setTextIsHtml(true)
 ```
+
 This method will parse the text with the `Html.fromHtml(text)` internally.
 
 ### TextForm

--- a/balloon/api/balloon.api
+++ b/balloon/api/balloon.api
@@ -262,6 +262,7 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun getDismissWhenTouchMargin ()Z
 	public final fun getDismissWhenTouchOutside ()Z
 	public final fun getElevation ()F
+	public final fun getEnableAutoSized ()Z
 	public final fun getHeight ()I
 	public final fun getIconColor ()I
 	public final fun getIconContentDescription ()Ljava/lang/CharSequence;
@@ -280,9 +281,11 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun getMarginLeft ()I
 	public final fun getMarginRight ()I
 	public final fun getMarginTop ()I
+	public final fun getMaxAutoSizeTextSize ()F
 	public final fun getMaxWidth ()I
 	public final fun getMaxWidthRatio ()F
 	public final fun getMeasuredWidth ()I
+	public final fun getMinAutoSizeTextSize ()F
 	public final fun getMinWidth ()I
 	public final fun getMinWidthRatio ()F
 	public final fun getMovementMethod ()Landroid/text/method/MovementMethod;
@@ -420,6 +423,8 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final synthetic fun setElevation (F)V
 	public final fun setElevation (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setElevationResource (I)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setEnableAutoSized (Z)Lcom/skydoves/balloon/Balloon$Builder;
+	public final synthetic fun setEnableAutoSized (Z)V
 	public final fun setFocusable (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setFocusable (Z)V
 	public final fun setHeight (I)Lcom/skydoves/balloon/Balloon$Builder;
@@ -483,6 +488,8 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun setMarginTopResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setMarginVertical (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setMarginVerticalResource (I)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setMaxAutoSizeTextSize (F)Lcom/skydoves/balloon/Balloon$Builder;
+	public final synthetic fun setMaxAutoSizeTextSize (F)V
 	public final fun setMaxWidth (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setMaxWidth (I)V
 	public final fun setMaxWidthRatio (F)Lcom/skydoves/balloon/Balloon$Builder;
@@ -490,6 +497,8 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun setMaxWidthResource (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setMeasuredWidth (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setMeasuredWidth (I)V
+	public final fun setMinAutoSizeTextSize (F)Lcom/skydoves/balloon/Balloon$Builder;
+	public final synthetic fun setMinAutoSizeTextSize (F)V
 	public final fun setMinWidth (I)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setMinWidth (I)V
 	public final fun setMinWidthRatio (F)Lcom/skydoves/balloon/Balloon$Builder;
@@ -865,7 +874,10 @@ public final class com/skydoves/balloon/PlacementType : java/lang/Enum {
 
 public final class com/skydoves/balloon/TextForm {
 	public synthetic fun <init> (Lcom/skydoves/balloon/TextForm$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getEnableAutoSized ()Z
 	public final fun getIncludeFontPadding ()Z
+	public final fun getMaxAutoSizeTextSize ()F
+	public final fun getMinAutoSizeTextSize ()F
 	public final fun getMovementMethod ()Landroid/text/method/MovementMethod;
 	public final fun getText ()Ljava/lang/CharSequence;
 	public final fun getTextColor ()I
@@ -882,7 +894,10 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public fun <init> (Landroid/content/Context;)V
 	public final fun build ()Lcom/skydoves/balloon/TextForm;
 	public final fun getContext ()Landroid/content/Context;
+	public final fun getEnableAutoSized ()Z
 	public final fun getIncludeFontPadding ()Z
+	public final fun getMaxAutoSizeTextSize ()F
+	public final fun getMinAutoSizeTextSize ()F
 	public final fun getMovementMethod ()Landroid/text/method/MovementMethod;
 	public final fun getText ()Ljava/lang/CharSequence;
 	public final fun getTextColor ()I
@@ -893,8 +908,14 @@ public final class com/skydoves/balloon/TextForm$Builder {
 	public final fun getTextSize ()F
 	public final fun getTextTypeface ()I
 	public final fun getTextTypefaceObject ()Landroid/graphics/Typeface;
+	public final fun setEnableAutoSized (Z)Lcom/skydoves/balloon/TextForm$Builder;
+	public final synthetic fun setEnableAutoSized (Z)V
 	public final fun setIncludeFontPadding (Z)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setIncludeFontPadding (Z)V
+	public final fun setMaxAutoSizeTextSize (F)Lcom/skydoves/balloon/TextForm$Builder;
+	public final synthetic fun setMaxAutoSizeTextSize (F)V
+	public final fun setMinAutoSizeTextSize (F)Lcom/skydoves/balloon/TextForm$Builder;
+	public final synthetic fun setMinAutoSizeTextSize (F)V
 	public final fun setMovementMethod (Landroid/text/method/MovementMethod;)Lcom/skydoves/balloon/TextForm$Builder;
 	public final synthetic fun setMovementMethod (Landroid/text/method/MovementMethod;)V
 	public final fun setText (Ljava/lang/CharSequence;)Lcom/skydoves/balloon/TextForm$Builder;

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -639,6 +639,9 @@ public class Balloon private constructor(
           setTextLineSpacing(builder.textLineSpacing)
           setTextLetterSpacing(builder.textLetterSpacing)
           setMovementMethod(builder.movementMethod)
+          setEnableAutoSized(builder.enableAutoSized)
+          setMinAutoSizeTextSize(builder.minAutoSizeTextSize)
+          setMaxAutoSizeTextSize(builder.maxAutoSizeTextSize)
         },
       )
       measureTextWidth(this, binding.balloonCard)
@@ -2164,6 +2167,15 @@ public class Balloon private constructor(
     public var textSize: Float = 12f
 
     @set:JvmSynthetic
+    public var enableAutoSized: Boolean = false
+
+    @set:JvmSynthetic
+    public var minAutoSizeTextSize: Float = textSize
+
+    @set:JvmSynthetic
+    public var maxAutoSizeTextSize: Float = textSize + 1
+
+    @set:JvmSynthetic
     public var textTypeface: Int = Typeface.NORMAL
 
     @set:JvmSynthetic
@@ -2812,6 +2824,21 @@ public class Balloon private constructor(
     /** sets the size of the main text content using dimension resource. */
     public fun setTextSizeResource(@DimenRes value: Int): Builder = apply {
       this.textSize = context.px2Sp(context.dimen(value))
+    }
+
+    /** Enables or disables the auto-sized text. */
+    public fun setEnableAutoSized(value: Boolean): Builder = apply {
+      this.enableAutoSized = value
+    }
+
+    /** Sets the minimum auto-sized text size. */
+    public fun setMinAutoSizeTextSize(@Sp value: Float): Builder = apply {
+      this.minAutoSizeTextSize = value
+    }
+
+    /** Sets the maximum auto-sized text size. */
+    public fun setMaxAutoSizeTextSize(@Sp value: Float): Builder = apply {
+      this.maxAutoSizeTextSize = value
     }
 
     /** sets the typeface of the main text content. */

--- a/balloon/src/main/kotlin/com/skydoves/balloon/TextForm.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/TextForm.kt
@@ -61,6 +61,12 @@ public class TextForm private constructor(
   @Sp
   public val textSize: Float = builder.textSize
 
+  public val enableAutoSized: Boolean = builder.enableAutoSized
+
+  public val minAutoSizeTextSize: Float = builder.minAutoSizeTextSize
+
+  public val maxAutoSizeTextSize: Float = builder.maxAutoSizeTextSize
+
   @ColorInt
   public val textColor: Int = builder.textColor
 
@@ -89,6 +95,15 @@ public class TextForm private constructor(
     @Sp
     @set:JvmSynthetic
     public var textSize: Float = 12f
+
+    @set:JvmSynthetic
+    public var enableAutoSized: Boolean = true
+
+    @set:JvmSynthetic
+    public var minAutoSizeTextSize: Float = textSize
+
+    @set:JvmSynthetic
+    public var maxAutoSizeTextSize: Float = textSize + 1
 
     @ColorInt
     @set:JvmSynthetic
@@ -120,6 +135,21 @@ public class TextForm private constructor(
 
     /** sets the content text of the form. */
     public fun setText(value: CharSequence): Builder = apply { this.text = value }
+
+    /** Enables or disables the auto-sized text. */
+    public fun setEnableAutoSized(value: Boolean): Builder = apply {
+      this.enableAutoSized = value
+    }
+
+    /** Sets the minimum auto-sized text size. */
+    public fun setMinAutoSizeTextSize(@Sp value: Float): Builder = apply {
+      this.minAutoSizeTextSize = value
+    }
+
+    /** Sets the maximum auto-sized text size. */
+    public fun setMaxAutoSizeTextSize(@Sp value: Float): Builder = apply {
+      this.maxAutoSizeTextSize = value
+    }
 
     /** sets the content text of the form using string resource. */
     public fun setTextResource(@StringRes value: Int): Builder = apply {

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/TextViewExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/TextViewExtension.kt
@@ -23,6 +23,7 @@ import android.text.Spanned
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.text.HtmlCompat
+import androidx.core.widget.TextViewCompat
 import com.skydoves.balloon.IconForm
 import com.skydoves.balloon.IconGravity
 import com.skydoves.balloon.TextForm
@@ -46,6 +47,15 @@ internal fun TextView.applyTextForm(textForm: TextForm) {
   textForm.textLetterSpacing?.let { letterSpacing = it }
   textForm.textTypeface?.let { typeface = it } ?: setTypeface(typeface, textForm.textStyle)
   textForm.movementMethod?.let { movementMethod = it }
+  if (textForm.enableAutoSized) {
+    TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(
+      this,
+      textForm.minAutoSizeTextSize.toInt(),
+      textForm.maxAutoSizeTextSize.toInt(),
+      1,
+      TextViewCompat.AUTO_SIZE_TEXT_TYPE_UNIFORM,
+    )
+  }
 }
 
 private fun fromHtml(text: String): Spanned? {
@@ -72,14 +82,17 @@ internal fun VectorTextView.applyIconForm(iconForm: IconForm) {
           drawableStart = iconForm.drawable
           drawableStartRes = iconForm.drawableRes
         }
+
         IconGravity.TOP -> {
           drawableTop = iconForm.drawable
           drawableTopRes = iconForm.drawableRes
         }
+
         IconGravity.BOTTOM -> {
           drawableBottom = iconForm.drawable
           drawableBottomRes = iconForm.drawableRes
         }
+
         IconGravity.END -> {
           drawableEnd = iconForm.drawable
           drawableEndRes = iconForm.drawableRes


### PR DESCRIPTION
### Auto-sized text

You can set auto-sized text based on the balloon's window size, specifying minimum and maximum text sizes, as shown in the example below:

```kotlin
.setTextSize(15f)
.setMinAutoSizeTextSize(14f)
.setMaxAutoSizeTextSize(18f)
.setEnableAutoSized(true)
```

> Note: Ensure that the maximum auto text size is set to a value higher than the minimum auto text size.