### PR TITLE
Enable isClipArrowEnabled by default by setting setBalloonStroke

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -2519,6 +2519,7 @@ public class Balloon private constructor(
      * @param thickness The thickness of the stroke in dp
      **/
     public fun setBalloonStroke(@ColorInt color: Int, @Dp thickness: Float): Builder = apply {
+      this.isClipArrowEnabled = true // For now, this will be enabled by default
       this.balloonStroke = BalloonStroke(color, thickness)
     }
 


### PR DESCRIPTION
[Enable isClipArrowEnabled by default by setting setBalloonStroke](https://github.com/skydoves/Balloon/commit/f637fb6f120d97a6ff66168d907e5148ee0abf19).