### PR TITLE
Migrate to Kotlin 2.3.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,10 +38,6 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
-  }
-
   buildFeatures {
     viewBinding = true
     compose = true
@@ -49,6 +45,12 @@ android {
 
   lint {
     abortOnError = false
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
   }
 }
 

--- a/balloon-compose/build.gradle.kts
+++ b/balloon-compose/build.gradle.kts
@@ -45,10 +45,6 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
-  kotlinOptions {
-    jvmTarget = libs.versions.jvmTarget.get()
-  }
-
   packaging {
     resources {
       excludes.add("/META-INF/{AL2.0,LGPL2.1}")
@@ -82,6 +78,7 @@ baselineProfile {
 
 kotlin {
   compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     freeCompilerArgs.addAll(
       "-Xexplicit-api=strict",
       "-opt-in=com.skydoves.balloon.annotations.InternalBalloonApi",

--- a/balloon/build.gradle.kts
+++ b/balloon/build.gradle.kts
@@ -61,10 +61,6 @@ android {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
-  kotlinOptions {
-    jvmTarget = libs.versions.jvmTarget.get()
-  }
-
   lint {
     abortOnError = false
   }
@@ -79,6 +75,7 @@ baselineProfile {
 
 kotlin {
   compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     freeCompilerArgs.addAll(
       "-Xexplicit-api=strict",
       "-opt-in=com.skydoves.balloon.annotations.InternalBalloonApi",

--- a/benchmark-app/build.gradle.kts
+++ b/benchmark-app/build.gradle.kts
@@ -39,10 +39,6 @@ android {
     targetCompatibility = JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = "17"
-  }
-
   buildFeatures {
     viewBinding = true
     compose = true
@@ -58,6 +54,12 @@ android {
       signingConfig = signingConfigs.getByName("debug")
       matchingFallbacks += listOf("release")
     }
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
   }
 }
 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -32,6 +32,12 @@ android {
   }
 }
 
+kotlin {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+  }
+}
+
 // This is the plugin configuration. Everything is optional. Defaults are in the
 // comments. In this example, you use the GMD added earlier and disable connected devices.
 baselineProfile {

--- a/buildSrc/src/main/kotlin/com/skydoves/balloon/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/balloon/Configuration.kt
@@ -19,7 +19,7 @@ package com.skydoves.balloon
 object Configuration {
   const val compileSdk = 36
   const val targetSdk = 36
-  const val minSdk = 21
+  const val minSdk = 23
   const val minSdkBenchmark = 23
   const val majorVersion = 1
   const val minorVersion = 6

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.13.2"
 dokka = "2.1.0"
-kotlin = "2.2.21"
+kotlin = "2.3.0"
 kotlinBinaryCompatibility = "0.18.1"
 jvmTarget = "11"
 nexusPlugin = "0.35.0"


### PR DESCRIPTION
Migrate to Kotlin 2.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum Android SDK requirement to API level 23 (Android 6.0)
  * Upgraded Kotlin compiler to version 2.3.0
  * Modernized build configuration structure

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->