### PR TITLE
Skip updating if the width and height sizes are smaller than 0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,10 +26,10 @@
     android:supportsRtl="true"
     android:theme="@style/AppTheme"
     tools:ignore="GoogleAppIndexingWarning">
-    <activity android:name=".ComposeActivity" />
+    <activity android:name=".CustomActivity" />
     <activity android:name=".MainActivity" />
     <activity
-      android:name=".CustomActivity"
+      android:name=".ComposeActivity"
       android:exported="true"
       android:theme="@style/AppTheme.NoActionBar">
       <intent-filter>

--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/Balloon.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/Balloon.kt
@@ -162,6 +162,7 @@ public fun Balloon(
               width = calculatedWidth,
               height = coordinates.size.height,
             )
+            if (size.width <= 0 || size.height <= 0) return@onGloballyPositioned
             balloonComposeView.updateSizeOfBalloonCard(size)
             balloonComposeView.balloonLayoutInfo.value = BalloonLayoutInfo(
               x = coordinates.positionInWindow().x,

--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonComposeView.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonComposeView.kt
@@ -312,6 +312,7 @@ internal class BalloonComposeView(
   override fun getBalloonArrowView(): View = balloon.getBalloonArrowView()
 
   internal fun updateSizeOfBalloonCard(size: IntSize) {
+    if (size.width <= 0 || size.height <= 0) return
     balloon.updateSizeOfBalloonCard(width = size.width, height = size.height)
     updateLayoutParams {
       width = size.width


### PR DESCRIPTION
Skip updating if the width and height sizes are smaller than 0 (#828 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced balloon component stability by preventing layout updates with invalid size calculations
  * Corrected activity declarations in app configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->