### PR TITLE
Use composition locals to get properly-scoped owners that respect navigation destinations

### DIFF
--- a/balloon-compose/build.gradle.kts
+++ b/balloon-compose/build.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
   implementation(libs.androidx.compose.runtime)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.lifecycle)
+  implementation(libs.androidx.lifecycle.runtime.compose)
+  implementation(libs.androidx.lifecycle.viewmodel.compose)
+  implementation(libs.androidx.savedstate.compose)
 
   baselineProfile(project(":benchmark"))
   dokkaPlugin(libs.android.documentation.plugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,9 @@ androidx-material = { module = "com.google.android.material:material", version.r
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
 androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "androidxFragment" }
 androidx-lifecycle = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
+androidx-savedstate-compose = { module = "androidx.savedstate:savedstate-compose", version = "1.3.0" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }


### PR DESCRIPTION
Use composition locals to get properly-scoped owners that respect navigation destinations. (#879)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak issue in navigation scenarios to improve app stability and memory management when transitioning between screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->