### PR TITLE
Migrate to Subcompose layout to measure layout sizes

### DIFF
--- a/app/src/main/kotlin/com/skydoves/balloondemo/ComposeActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/balloondemo/ComposeActivity.kt
@@ -426,7 +426,9 @@ private fun EditProfileSection(onToast: (String) -> Unit) {
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-          text =  "Now you can edit your profile1 profile2 profile3 profile4 really long text so we can test stuff Now you can edit your profile1 profile2 profile3 profile4 really long text so we can test stuff",
+          text = "Now you can edit your profile1 profile2 profile3 profile4 " +
+            "really long text so we can test stuff Now you can edit your " +
+            "profile1 profile2 profile3 profile4 really long text so we can test stuff",
           color = Color.White,
           fontSize = 14.sp,
         )


### PR DESCRIPTION
Migrate to Subcompose layout to measure layout sizes. (#786)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized balloon content measurement and positioning system for improved layout reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->