### PR TITLE
Disable focus to prevent focus highlight on D-pad navigation

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -722,6 +722,27 @@ public class Balloon private constructor(
         builder.marginRight,
         builder.marginBottom,
       )
+      // Disable focus to prevent focus highlight on D-pad navigation (issue #258)
+      isFocusable = false
+      isFocusableInTouchMode = false
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        defaultFocusHighlightEnabled = false
+      }
+    }
+    // Also disable focus on the root and content views
+    with(binding.root) {
+      isFocusable = false
+      isFocusableInTouchMode = false
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        defaultFocusHighlightEnabled = false
+      }
+    }
+    with(binding.balloonCard) {
+      isFocusable = false
+      isFocusableInTouchMode = false
+      if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+        defaultFocusHighlightEnabled = false
+      }
     }
   }
 

--- a/balloon/src/main/res/layout/balloon_layout_body.xml
+++ b/balloon/src/main/res/layout/balloon_layout_body.xml
@@ -25,7 +25,8 @@
     android:id="@+id/balloon_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:focusable="true"
+    android:focusable="false"
+    android:focusableInTouchMode="false"
     tools:ignore="UselessParent">
 
     <FrameLayout


### PR DESCRIPTION
Disable focus to prevent focus highlight on D-pad navigation (#258)