### PR TITLE
Add isClippingEnabled property

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -699,6 +699,7 @@ public class Balloon private constructor(
     with(this.bodyWindow) {
       isOutsideTouchable = true
       isFocusable = builder.isFocusable
+      isClippingEnabled = builder.isClippingEnabled
       setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
       elevation = builder.elevation
       setIsAttachedInDecor(builder.isAttachedInDecor)
@@ -2537,6 +2538,9 @@ public class Balloon private constructor(
     public var isAttachedInDecor: Boolean = true
 
     @set:JvmSynthetic
+    public var isClippingEnabled: Boolean = true
+
+    @set:JvmSynthetic
     public var isComposableContent: Boolean = false
 
     @set:JvmSynthetic
@@ -3284,6 +3288,16 @@ public class Balloon private constructor(
      */
     public fun setIsAttachedInDecor(value: Boolean): Builder = apply {
       this.isAttachedInDecor = value
+    }
+
+    /**
+     * Sets whether the popup window will be clipped to the screen bounds.
+     * When set to false, the balloon can extend beyond screen boundaries,
+     * which is useful for maintaining position relative to anchor views in scrollable containers.
+     * Default is true for backward compatibility.
+     */
+    public fun setIsClippingEnabled(value: Boolean): Builder = apply {
+      this.isClippingEnabled = value
     }
 
     /**


### PR DESCRIPTION
Add isClippingEnabled property (#914)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control popup clipping behavior. Users can now enable or disable whether popups are constrained to screen bounds, allowing greater flexibility in popup positioning and rendering across different application layouts and scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->