### PR TITLE
Add BalloonState.update() function to remeasure the layout contents

### DIFF
--- a/balloon-compose/api/balloon-compose.api
+++ b/balloon-compose/api/balloon-compose.api
@@ -94,6 +94,7 @@ public final class com/skydoves/balloon/compose/BalloonState : com/skydoves/ball
 	public fun showAlignTop (II)V
 	public fun showAsDropDown (II)V
 	public fun showAtCenter (IILcom/skydoves/balloon/BalloonCenterAlign;)V
+	public final fun update ()V
 	public fun update (II)V
 	public fun updateAlign (Lcom/skydoves/balloon/BalloonAlign;II)V
 	public fun updateAlignBottom (II)V

--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
@@ -109,6 +109,11 @@ public fun Modifier.balloon(
   // Track balloon layout info for measurement
   val balloonLayoutInfo = remember { mutableStateOf<BalloonLayoutInfo?>(null) }
 
+  // Connect layout info to state for update() functionality
+  remember(balloonLayoutInfo) {
+    state._balloonLayoutInfo = balloonLayoutInfo
+  }
+
   // Create BalloonComposeView and connect to state
   val balloonComposeView = remember(key) {
     BalloonComposeView(

--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonState.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonState.kt
@@ -21,6 +21,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -91,6 +92,9 @@ public class BalloonState internal constructor(
 
   /** The internal balloon window delegate. Set internally by the balloon modifier. */
   internal var _balloonWindow: BalloonWindow? = null
+
+  /** The balloon layout info state for triggering re-measurement. Set internally by the balloon modifier. */
+  internal var _balloonLayoutInfo: MutableState<BalloonLayoutInfo?>? = null
 
   override val anchorView: View
     get() = _anchorView
@@ -318,9 +322,29 @@ public class BalloonState internal constructor(
   override fun getBalloonArrowView(): View =
     _balloonWindow?.getBalloonArrowView() ?: error("BalloonState is not attached")
 
+  /**
+   * Triggers re-measurement of the balloon content.
+   * Call this method when the balloon content changes dynamically (e.g., showing/hiding elements)
+   * to update the balloon size without closing it.
+   *
+   * Example usage:
+   * ```
+   * var showExtra by remember { mutableStateOf(false) }
+   *
+   * Button(onClick = {
+   *   showExtra = !showExtra
+   *   balloonState.update() // Trigger re-measurement after content change
+   * })
+   * ```
+   */
+  public fun update() {
+    _balloonLayoutInfo?.value = null
+  }
+
   internal fun dispose() {
     _balloonWindow?.dismiss()
     _balloonWindow = null
     _anchorView = null
+    _balloonLayoutInfo = null
   }
 }

--- a/balloon/api/balloon.api
+++ b/balloon/api/balloon.api
@@ -333,6 +333,7 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun getWidthRatio ()F
 	public final fun isAttachedInDecor ()Z
 	public final fun isClipArrowEnabled ()Z
+	public final fun isClippingEnabled ()Z
 	public final fun isComposableContent ()Z
 	public final fun isFocusable ()Z
 	public final fun isRtlLayout ()Z
@@ -421,6 +422,7 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final fun setCircularDuration (J)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setCircularDuration (J)V
 	public final synthetic fun setClipArrowEnabled (Z)V
+	public final synthetic fun setClippingEnabled (Z)V
 	public final synthetic fun setComposableContent (Z)V
 	public final fun setCornerRadius (F)Lcom/skydoves/balloon/Balloon$Builder;
 	public final synthetic fun setCornerRadius (F)V
@@ -475,6 +477,7 @@ public final class com/skydoves/balloon/Balloon$Builder {
 	public final synthetic fun setIncludeFontPadding (Z)V
 	public final fun setIsAttachedInDecor (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setIsClipArrowEnabled (Z)Lcom/skydoves/balloon/Balloon$Builder;
+	public final fun setIsClippingEnabled (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setIsComposableContent (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setIsStatusBarVisible (Z)Lcom/skydoves/balloon/Balloon$Builder;
 	public final fun setIsVisibleArrow (Z)Lcom/skydoves/balloon/Balloon$Builder;


### PR DESCRIPTION
Add BalloonState.update() function to remeasure the layout contents. (#860)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a new `update()` method to refresh balloon content positioning and layout measurements
* Introduced clipping control options in the balloon builder to customize overflow behavior for balloon content

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->