### PR TITLE
Calculate transition x, y values for the showAsDropDown

### DIFF
--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
@@ -231,14 +231,8 @@ public fun Modifier.balloon(
           return@Layout layout(0, 0) {}
         }
 
-        // Use screen width as fallback for unbounded width constraints
         val effectiveMaxWidth = if (isUnboundedWidth) screenWidth else constraints.maxWidth
-        // Use a reasonable max height when unbounded (screen height equivalent)
-        val effectiveMaxHeight = if (isUnboundedHeight) {
-          (screenWidth * 2) // Use 2x screen width as a reasonable max height fallback
-        } else {
-          constraints.maxHeight
-        }
+        val effectiveMaxHeight = if (isUnboundedHeight) screenWidth * 2 else constraints.maxHeight
 
         val maxContentWidth = when {
           builder.widthRatio > 0f ->

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -1011,7 +1011,9 @@ public class Balloon private constructor(
         startBalloonHighlightAnimation()
 
         val (xOff, yOff) = calculateOffset(placement)
-        bodyWindow.showAsDropDown(mainAnchor, xOff, yOff)
+        val adjustedXOff = xOff + mainAnchor.translationX.toInt()
+        val adjustedYOff = yOff + mainAnchor.translationY.toInt()
+        bodyWindow.showAsDropDown(mainAnchor, adjustedXOff, adjustedYOff)
       }
     } else if (builder.dismissWhenShowAgain) {
       dismiss()
@@ -1727,10 +1729,12 @@ public class Balloon private constructor(
       }
 
       val (xOff, yOff) = calculateOffset(placement)
+      val adjustedXOff = xOff + placement.anchor.translationX.toInt()
+      val adjustedYOff = yOff + placement.anchor.translationY.toInt()
       this.bodyWindow.update(
         placement.anchor,
-        xOff,
-        yOff,
+        adjustedXOff,
+        adjustedYOff,
         placement.width,
         placement.height,
       )

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ViewExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ViewExtension.kt
@@ -41,7 +41,7 @@ internal fun View.visible(shouldVisible: Boolean) {
 internal fun View.getViewPointOnScreen(): Point {
   val location: IntArray = intArrayOf(0, 0)
   getLocationOnScreen(location)
-  return Point(location[0], location[1])
+  return Point(location[0] + translationX.toInt(), location[1] + translationY.toInt())
 }
 
 /** returns the status bar height if the anchor is on the Activity. */

--- a/balloon/src/main/kotlin/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
@@ -153,6 +153,7 @@ public class BalloonAnchorOverlayView @JvmOverloads constructor(
     view?.let { anchor ->
       val rect = Rect()
       anchor.getGlobalVisibleRect(rect)
+      rect.offset(anchor.translationX.toInt(), anchor.translationY.toInt())
       val anchorRect = overlayPosition?.let { position ->
         RectF(
           position.x - overlayPadding.left,


### PR DESCRIPTION
Calculate transition x, y values for the showAsDropDown (#919)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed balloon positioning to correctly account for translated anchor views, ensuring popups display at the expected location regardless of anchor transform state.

* **Refactor**
  * Simplified internal calculation logic for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->