### PR TITLE
Use findContext for looking up app context

### DIFF
--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
@@ -16,7 +16,6 @@
 
 package com.skydoves.balloon.compose
 
-import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -47,6 +46,8 @@ import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.skydoves.balloon.BalloonSizeSpec
+import com.skydoves.balloon.annotations.InternalBalloonApi
+import com.skydoves.balloon.extensions.findActivity
 import java.util.UUID
 
 /**
@@ -93,6 +94,7 @@ import java.util.UUID
  * @param balloonContent The composable content to display inside the balloon.
  * @return A modifier that attaches the balloon to this composable.
  */
+@OptIn(InternalBalloonApi::class)
 @Composable
 public fun Modifier.balloon(
   state: BalloonState,
@@ -116,7 +118,7 @@ public fun Modifier.balloon(
   // Get the parent view for the anchor. Use custom anchorParent if provided,
   // otherwise fall back to the activity's decor view.
   val parentView = remember(context, anchorParent) {
-    anchorParent ?: (context as? Activity)?.window?.decorView as? ViewGroup
+    anchorParent ?: context.findActivity()?.window?.decorView as? ViewGroup
   }
 
   // Create an invisible anchor view that will be added to the parent view

--- a/balloon/api/balloon.api
+++ b/balloon/api/balloon.api
@@ -1034,6 +1034,10 @@ public final class com/skydoves/balloon/animations/BalloonRotateDirection : java
 public abstract interface annotation class com/skydoves/balloon/annotations/InternalBalloonApi : java/lang/annotation/Annotation {
 }
 
+public final class com/skydoves/balloon/extensions/ContextExtensionKt {
+	public static final synthetic fun findActivity (Landroid/content/Context;)Landroid/app/Activity;
+}
+
 public final class com/skydoves/balloon/overlay/BalloonAnchorOverlayView : android/view/View {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V

--- a/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/Balloon.kt
@@ -19,7 +19,6 @@
 package com.skydoves.balloon
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Bitmap
@@ -93,6 +92,7 @@ import com.skydoves.balloon.extensions.dimen
 import com.skydoves.balloon.extensions.dimenPixel
 import com.skydoves.balloon.extensions.displaySize
 import com.skydoves.balloon.extensions.dp
+import com.skydoves.balloon.extensions.findActivity
 import com.skydoves.balloon.extensions.getIntrinsicHeight
 import com.skydoves.balloon.extensions.getStatusBarHeight
 import com.skydoves.balloon.extensions.getSumOfIntrinsicWidth
@@ -1096,7 +1096,7 @@ public class Balloon private constructor(
     if (destroyed) return false
 
     // If the Activity is finishing, we can't attach the popupWindow to the Activity's window. (#92)
-    if ((context as? Activity)?.isFinishing == true) return false
+    if (context.findActivity()?.isFinishing == true) return false
 
     // We should check the contentView is already attached to the decorView or backgroundView in the popupWindow.
     // Sometimes there is a concurrency issue between show and dismiss the popupWindow. (#149)

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ContextExtension.kt
@@ -16,11 +16,30 @@
 
 package com.skydoves.balloon.extensions
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.drawable.Drawable
 import androidx.annotation.DimenRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
+import com.skydoves.balloon.annotations.InternalBalloonApi
+
+/**
+ * Recursively unwraps [ContextWrapper] layers to find the underlying [Activity].
+ * This handles cases like Hilt's [FragmentContextWrapper] where the context
+ * is not directly an [Activity] but wraps one.
+ */
+@InternalBalloonApi
+@JvmSynthetic
+public fun Context.findActivity(): Activity? {
+  var ctx = this
+  while (ctx is ContextWrapper) {
+    if (ctx is Activity) return ctx
+    ctx = ctx.baseContext
+  }
+  return null
+}
 
 /** px size to sp size. */
 @JvmSynthetic

--- a/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ViewExtension.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/extensions/ViewExtension.kt
@@ -18,7 +18,6 @@ package com.skydoves.balloon.extensions
 
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
-import android.app.Activity
 import android.graphics.Point
 import android.graphics.Rect
 import android.view.View
@@ -49,8 +48,9 @@ internal fun View.getViewPointOnScreen(): Point {
 internal fun View.getStatusBarHeight(isStatusBarVisible: Boolean): Int {
   val rectangle = Rect()
   val context = context
-  return if (context is Activity && isStatusBarVisible) {
-    context.window.decorView.getWindowVisibleDisplayFrame(rectangle)
+  val activity = context.findActivity()
+  return if (activity != null && isStatusBarVisible) {
+    activity.window.decorView.getWindowVisibleDisplayFrame(rectangle)
     rectangle.top
   } else {
     0

--- a/balloon/src/main/kotlin/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/overlay/BalloonAnchorOverlayView.kt
@@ -16,7 +16,6 @@
 
 package com.skydoves.balloon.overlay
 
-import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -35,6 +34,7 @@ import androidx.annotation.ColorInt
 import androidx.core.graphics.createBitmap
 import com.skydoves.balloon.BalloonOverlayPadding
 import com.skydoves.balloon.extensions.dimen
+import com.skydoves.balloon.extensions.findActivity
 import com.skydoves.balloon.internals.viewProperty
 
 /**
@@ -314,8 +314,9 @@ public class BalloonAnchorOverlayView @JvmOverloads constructor(
   private fun getStatusBarHeight(): Int {
     val rectangle = Rect()
     val context = context
-    return if (context is Activity) {
-      context.window.decorView.getWindowVisibleDisplayFrame(rectangle)
+    val activity = context.findActivity()
+    return if (activity != null) {
+      activity.window.decorView.getWindowVisibleDisplayFrame(rectangle)
       rectangle.top
     } else {
       0


### PR DESCRIPTION
Use findContext for looking up app context (#953)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal Activity resolution mechanism across balloon components, improving how the library locates and interacts with parent activity context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->