### PR TITLE
Set the min height size

### DIFF
--- a/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
+++ b/balloon-compose/src/main/kotlin/com/skydoves/balloon/compose/BalloonModifier.kt
@@ -247,7 +247,7 @@ public fun Modifier.balloon(
           builder.height != BalloonSizeSpec.WRAP -> builder.height
           isUnboundedHeight -> screenWidth * 2
           else -> constraints.maxHeight
-        }
+        }.coerceAtLeast(0)
 
         val maxContentWidth = when {
           builder.widthRatio > 0f ->


### PR DESCRIPTION
Set the min height size (#963)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a layout measurement issue that could cause incorrect balloon component sizing under certain height configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->