### PR TITLE
Respect user provided cornerRadius

### DIFF
--- a/balloon/src/main/kotlin/com/skydoves/balloon/radius/RadiusLayout.kt
+++ b/balloon/src/main/kotlin/com/skydoves/balloon/radius/RadiusLayout.kt
@@ -294,7 +294,16 @@ public class RadiusLayout @JvmOverloads constructor(
 
       canvas.restoreToCount(save)
     } else {
-      super.dispatchDraw(canvas)
+      // Clip children to the rounded rect so user-provided layouts respect cornerRadius
+      // even when isClipArrowEnabled is false (issue #970).
+      if (radius > 0f && !path.isEmpty) {
+        val save = canvas.save()
+        canvas.clipPath(path)
+        super.dispatchDraw(canvas)
+        canvas.restoreToCount(save)
+      } else {
+        super.dispatchDraw(canvas)
+      }
     }
   }
 }


### PR DESCRIPTION
Respect user provided cornerRadius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rounded corner clipping in layout containers. Child view elements are now consistently clipped to respect rounded corner boundaries in all rendering modes. Previously, when custom shape mode was disabled, child views could overflow and visually extend beyond the defined rounded corners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->