### PR TITLE
Add a liquid glass tooltip demo built on Cloudy

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
 }
 
 android {
-  compileSdk = Configuration.compileSdk
+  compileSdk = Configuration.compileSdkDemo
   namespace = "com.skydoves.balloon.kmpdemo"
 
   sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")

--- a/buildSrc/src/main/kotlin/com/skydoves/balloon/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/balloon/Configuration.kt
@@ -18,6 +18,15 @@ package com.skydoves.balloon
 
 object Configuration {
   const val compileSdk = 36
+
+  /**
+   * Compile SDK for the demo modules only.
+   *
+   * `cloudy`, which the glass tooltip demo uses, declares `minCompileSdk=37`. The published
+   * library stays on 36 on purpose: its own `minCompileSdk` is part of what it asks of every
+   * consumer, and a demo dependency is no reason to raise that.
+   */
+  const val compileSdkDemo = 37
   const val targetSdk = 36
   const val minSdk = 23
   const val minSdkBenchmark = 23

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jvmTarget = "11"
 nexusPlugin = "0.37.0"
 composeMultiplatform = "1.10.3"
 androidxActivity = "1.13.0"
+cloudy = "1.0.0-alpha01"
 spotless = "6.21.0"
 androidxMacroBenchmark = "1.5.0-rc02"
 androidxTest = "1.7.0"
@@ -33,6 +34,7 @@ compose-multiplatform-material = { module = "org.jetbrains.compose.material:mate
 compose-multiplatform-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
 
 # Demo apps
+compose-cloudy = { module = "com.github.skydoves:cloudy", version.ref = "cloudy" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 
 # Baseline profile generation (`:benchmark`, and the profileinstaller the demo needs)

--- a/samples-shared/build.gradle.kts
+++ b/samples-shared/build.gradle.kts
@@ -35,9 +35,9 @@ kotlin {
   androidTarget()
   jvm("desktop")
 
-  @Suppress("DEPRECATION")
+  // No `iosX64` here, unlike `:balloon`, because the glass demo depends on `cloudy`, which
+  // does not publish an Intel simulator artifact. The library itself still targets it.
   listOf(
-    iosX64(),
     iosArm64(),
     iosSimulatorArm64(),
   ).forEach {
@@ -66,7 +66,6 @@ kotlin {
         withJvm()
         group("apple") {
           group("ios") {
-            withIosX64()
             withIosArm64()
             withIosSimulatorArm64()
           }
@@ -91,6 +90,8 @@ kotlin {
         implementation(libs.compose.multiplatform.material)
         // Ships the demo's profile picture to every target.
         implementation(libs.compose.multiplatform.resources)
+        // Blur and liquid glass, used by the glass tooltip demo.
+        implementation(libs.compose.cloudy)
       }
     }
     val commonTest by getting {
@@ -109,7 +110,7 @@ compose.resources {
 }
 
 android {
-  compileSdk = Configuration.compileSdk
+  compileSdk = Configuration.compileSdkDemo
   namespace = "com.skydoves.balloon.sample"
 
   defaultConfig {

--- a/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/BalloonDemoScreen.kt
+++ b/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/BalloonDemoScreen.kt
@@ -108,12 +108,14 @@ private val Orange = Color(0xFFFF5722)
  * @param onMessage invoked with a human-readable message when a demo action is triggered
  *   (the KMP stand-in for the original demo's `Toast`s).
  * @param onOpenLabs invoked when the Labs entry point is clicked; the host is expected to
+ * @param onOpenGlass invoked when the glass tooltip demo entry is pressed.
  *   navigate to [com.skydoves.balloon.sample.labs.BalloonLabsScreen].
  */
 @Composable
 public fun BalloonDemoScreen(
   onMessage: (String) -> Unit = {},
   onOpenLabs: () -> Unit = {},
+  onOpenGlass: () -> Unit = {},
 ) {
   // `Modifier.balloon` registers anchors with the nearest host, which is what actually
   // emits the popups. One host wraps the whole screen.
@@ -158,7 +160,7 @@ public fun BalloonDemoScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         // Labs Entry Point
-        LabsEntry(onOpenLabs = onOpenLabs)
+        LabsEntry(onOpenLabs = onOpenLabs, onOpenGlass = onOpenGlass)
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -456,7 +458,7 @@ private fun EditProfileSection() {
 }
 
 @Composable
-private fun LabsEntry(onOpenLabs: () -> Unit) {
+private fun LabsEntry(onOpenLabs: () -> Unit, onOpenGlass: () -> Unit) {
   Text(
     text = "Labs",
     color = White70,
@@ -493,6 +495,25 @@ private fun LabsEntry(onOpenLabs: () -> Unit) {
     Spacer(modifier = Modifier.width(8.dp))
     Text(
       text = "Open Balloon Labs",
+      color = Color.White,
+      fontSize = 14.sp,
+      fontWeight = FontWeight.Bold,
+    )
+  }
+
+  Spacer(modifier = Modifier.height(10.dp))
+
+  Button(
+    onClick = onOpenGlass,
+    colors = ButtonDefaults.buttonColors(backgroundColor = Teal),
+    shape = RoundedCornerShape(8.dp),
+    elevation = ButtonDefaults.elevation(0.dp),
+    modifier = Modifier
+      .fillMaxWidth()
+      .height(48.dp),
+  ) {
+    Text(
+      text = "Glass tooltips (Cloudy)",
       color = Color.White,
       fontSize = 14.sp,
       fontWeight = FontWeight.Bold,

--- a/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/BalloonSampleApp.kt
+++ b/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/BalloonSampleApp.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.skydoves.balloon.sample.glass.GlassTooltipScreen
 import com.skydoves.balloon.sample.labs.BalloonLabsScreen
 
 /**
@@ -32,13 +33,14 @@ import com.skydoves.balloon.sample.labs.BalloonLabsScreen
 private enum class SampleScreen {
   Demo,
   Labs,
+  Glass,
 }
 
 /**
  * Single entry point shared by every demo app (Android, iOS, Desktop, Wasm).
  *
- * It owns the sample's navigation state and swaps between [BalloonDemoScreen] and
- * [BalloonLabsScreen]. Platform entry points should call this instead of rendering a
+ * It owns the sample's navigation state and swaps between [BalloonDemoScreen],
+ * [BalloonLabsScreen], and [GlassTooltipScreen]. Platform entry points should call this instead of rendering a
  * screen directly, so every target reaches the same set of screens.
  *
  * The state is a plain [remember], not `rememberSaveable`: the sample intentionally
@@ -55,9 +57,14 @@ public fun BalloonSampleApp(onMessage: (String) -> Unit = {}) {
     SampleScreen.Demo -> BalloonDemoScreen(
       onMessage = onMessage,
       onOpenLabs = { screen = SampleScreen.Labs },
+      onOpenGlass = { screen = SampleScreen.Glass },
     )
 
     SampleScreen.Labs -> BalloonLabsScreen(
+      onBack = { screen = SampleScreen.Demo },
+    )
+
+    SampleScreen.Glass -> GlassTooltipScreen(
       onBack = { screen = SampleScreen.Demo },
     )
   }

--- a/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/glass/GlassTooltipParts.kt
+++ b/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/glass/GlassTooltipParts.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright (C) 2019 skydoves
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.balloon.sample.glass
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.skydoves.balloon.ArrowPositionRules
+import com.skydoves.balloon.Balloon
+import com.skydoves.balloon.BalloonAnimation
+import com.skydoves.balloon.rememberBalloonBuilder
+import com.skydoves.balloon.rememberBalloonState
+import com.skydoves.cloudy.Sky
+import com.skydoves.cloudy.cloudy
+import com.skydoves.cloudy.liquidGlass
+import com.skydoves.cloudy.sky
+
+internal val Backdrop = Color(0xFF0E1013)
+private val GlassShape = RoundedCornerShape(20.dp)
+private val BarShape = RoundedCornerShape(16.dp)
+private val White = Color.White
+
+/** One tile in the grid, and the detail the tooltip shows for it. */
+internal data class GalleryItem(
+  val title: String,
+  val meta: String,
+  val detail: String,
+  val start: Color,
+  val end: Color,
+)
+
+internal val GalleryItems: List<GalleryItem> = listOf(
+  GalleryItem(
+    "Aurora",
+    "4032 x 3024  ·  6.1 MB",
+    "Shot at ISO 800, f/1.8, 1/60s",
+    Color(0xFFFF5F6D),
+    Color(0xFFFFC371),
+  ),
+  GalleryItem(
+    "Harbour",
+    "3024 x 4032  ·  4.4 MB",
+    "Shot at ISO 200, f/2.8, 1/250s",
+    Color(0xFF2E3192),
+    Color(0xFF1BFFFF),
+  ),
+  GalleryItem(
+    "Dune",
+    "4032 x 3024  ·  5.2 MB",
+    "Shot at ISO 100, f/8.0, 1/500s",
+    Color(0xFFF7971E),
+    Color(0xFFFFD200),
+  ),
+  GalleryItem(
+    "Fern",
+    "3024 x 3024  ·  3.8 MB",
+    "Shot at ISO 400, f/2.0, 1/125s",
+    Color(0xFF11998E),
+    Color(0xFF38EF7D),
+  ),
+  GalleryItem(
+    "Neon",
+    "4032 x 2268  ·  7.9 MB",
+    "Shot at ISO 1600, f/1.4, 1/30s",
+    Color(0xFFB621FE),
+    Color(0xFF1FD1F9),
+  ),
+  GalleryItem(
+    "Tide",
+    "3024 x 4032  ·  4.9 MB",
+    "Shot at ISO 320, f/4.0, 1/200s",
+    Color(0xFFEE0979),
+    Color(0xFFFF6A00),
+  ),
+  GalleryItem(
+    "Basalt",
+    "4032 x 3024  ·  6.7 MB",
+    "Shot at ISO 250, f/5.6, 1/160s",
+    Color(0xFF373B44),
+    Color(0xFF4286F4),
+  ),
+  GalleryItem(
+    "Pollen",
+    "3024 x 3024  ·  3.1 MB",
+    "Shot at ISO 125, f/3.2, 1/400s",
+    Color(0xFFF12711),
+    Color(0xFFF5AF19),
+  ),
+)
+
+@Composable
+internal fun GlassTopBar(onBack: () -> Unit) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(
+        start = 16.dp,
+        end = 16.dp,
+        top = 14.dp + WindowInsets.statusBars.asPaddingValues().calculateTopPadding(),
+        bottom = 14.dp,
+      ),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Box(
+      modifier = Modifier
+        .size(34.dp)
+        .clip(CircleShape)
+        .background(White.copy(alpha = 0.10f))
+        .clickable(onClick = onBack),
+      contentAlignment = Alignment.Center,
+    ) { Text("<", color = White, fontSize = 16.sp, fontWeight = FontWeight.Bold) }
+    Spacer(Modifier.width(12.dp))
+    Column {
+      Text("Glass tooltips", color = White, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+      Text(
+        text = "Tap a tile. The tooltip refracts the grid instead of hiding it.",
+        color = White.copy(alpha = 0.55f),
+        fontSize = 12.sp,
+      )
+    }
+  }
+}
+
+/**
+ * A grid tile that owns its own balloon.
+ *
+ * The anchor is the tile, so the tooltip lands over its neighbours, which is exactly where an
+ * opaque tooltip would cost you the comparison you were making.
+ */
+@Composable
+internal fun GalleryCard(
+  item: GalleryItem,
+  sky: Sky,
+  blurRadius: Int,
+  lensEnabled: Boolean,
+) {
+  val style = rememberBalloonBuilder(lensEnabled to blurRadius) {
+    // Transparent body: every visible pixel of the panel comes from the glass, not from a
+    // fill. The arrow keeps a faint white so it still reads as the same surface.
+    setBackgroundColor(White.copy(alpha = 0.13f))
+    setArrowSize(width = 18.dp, height = 10.dp)
+    setArrowPositionRules(ArrowPositionRules.ALIGN_ANCHOR)
+    setCornerRadius(20.dp)
+    setPadding(0.dp)
+    setMarginHorizontal(12.dp)
+    setBalloonAnimation(BalloonAnimation.FADE)
+    setDismissWhenTouchOutside(true)
+  }
+  val state = rememberBalloonState(style)
+
+  Balloon(
+    state = state,
+    balloonContent = {
+      GlassPanel(item = item, sky = sky, blurRadius = blurRadius, lensEnabled = lensEnabled)
+    },
+  ) {
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .aspectRatio(1f)
+        .clip(RoundedCornerShape(18.dp))
+        .background(Brush.linearGradient(listOf(item.start, item.end)))
+        .clickable { state.toggle() },
+      contentAlignment = Alignment.BottomStart,
+    ) {
+      Column(modifier = Modifier.padding(12.dp)) {
+        Text(item.title, color = White, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+        Text(item.meta, color = White.copy(alpha = 0.8f), fontSize = 11.sp)
+      }
+    }
+  }
+}
+
+/**
+ * The tooltip body.
+ *
+ * `cloudy(sky = ...)` draws the captured grid back, blurred and clipped to this panel.
+ * `liquidGlass` then bends that drawing near the edges, which is what separates a lens from a
+ * translucent rectangle. The border is a plain gradient stroke standing in for the bright rim
+ * a real piece of glass catches.
+ */
+@Composable
+private fun GlassPanel(
+  item: GalleryItem,
+  sky: Sky,
+  blurRadius: Int,
+  lensEnabled: Boolean,
+) {
+  val width = 250.dp
+  val height = 132.dp
+  val density = LocalDensity.current
+  val lensSize = with(density) { Size(width.toPx(), height.toPx()) }
+  val lensCenter = Offset(lensSize.width / 2f, lensSize.height / 2f)
+
+  Box(
+    modifier = Modifier
+      .size(width, height)
+      .cloudy(
+        sky = sky,
+        radius = blurRadius,
+        shape = GlassShape,
+        // A tooltip has to stay readable over whatever it lands on, and this grid runs from
+        // near white to saturated red. A slight dark tint keeps the white text legible
+        // without turning the panel back into an opaque box.
+        tint = Backdrop.copy(alpha = 0.34f),
+      )
+      .then(
+        if (lensEnabled) {
+          Modifier.liquidGlass(
+            lensCenter = lensCenter,
+            lensSize = lensSize,
+            cornerRadius = with(density) { 20.dp.toPx() },
+            refraction = 0.22f,
+            curve = 0.30f,
+            dispersion = 0.04f,
+            saturation = 1.15f,
+            contrast = 1.05f,
+            edge = 0.25f,
+          )
+        } else {
+          Modifier
+        },
+      )
+      .border(
+        width = 1.dp,
+        brush = Brush.linearGradient(
+          listOf(White.copy(alpha = 0.45f), White.copy(alpha = 0.10f)),
+        ),
+        shape = GlassShape,
+      )
+      .padding(16.dp),
+  ) {
+    Column {
+      Text(item.title, color = White, fontSize = 17.sp, fontWeight = FontWeight.Bold)
+      Spacer(Modifier.height(4.dp))
+      Text(item.meta, color = White.copy(alpha = 0.75f), fontSize = 12.sp)
+      Spacer(Modifier.height(2.dp))
+      Text(item.detail, color = White.copy(alpha = 0.75f), fontSize = 12.sp)
+      Spacer(Modifier.height(10.dp))
+      Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        GlassChip("Open")
+        GlassChip("Share")
+      }
+    }
+  }
+}
+
+@Composable
+private fun GlassChip(label: String) {
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(8.dp))
+      .background(White.copy(alpha = 0.18f))
+      .padding(horizontal = 12.dp, vertical = 5.dp),
+  ) { Text(label, color = White, fontSize = 12.sp, fontWeight = FontWeight.Bold) }
+}
+
+/** Enough of a control surface to see what each parameter is actually doing. */
+@Composable
+internal fun GlassControls(
+  sky: Sky,
+  lensEnabled: Boolean,
+  onLensChange: (Boolean) -> Unit,
+  blurRadius: Int,
+  onBlurChange: (Int) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(
+        start = 16.dp,
+        end = 16.dp,
+        top = 16.dp,
+        bottom = 16.dp +
+          WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding(),
+      )
+      .clip(BarShape)
+      // The same backdrop API the tooltip uses, doing the ordinary job it is usually hired
+      // for. Without it this bar sits unreadable on top of the tiles.
+      .cloudy(sky = sky, radius = 32, shape = BarShape, tint = Color.Black.copy(alpha = 0.35f))
+      .border(1.dp, White.copy(alpha = 0.16f), BarShape)
+      .padding(horizontal = 14.dp, vertical = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Toggle("Lens", lensEnabled) { onLensChange(!lensEnabled) }
+    Spacer(Modifier.width(4.dp))
+    Text("Blur", color = White.copy(alpha = 0.7f), fontSize = 12.sp)
+    listOf(0, 14, 28, 44).forEach { r ->
+      Toggle(if (r == 0) "off" else "$r", blurRadius == r) { onBlurChange(r) }
+    }
+  }
+}
+
+@Composable
+private fun Toggle(label: String, selected: Boolean, onClick: () -> Unit) {
+  Box(
+    modifier = Modifier
+      .clip(RoundedCornerShape(9.dp))
+      .background(if (selected) White.copy(alpha = 0.26f) else White.copy(alpha = 0.07f))
+      .clickable(onClick = onClick)
+      .padding(horizontal = 11.dp, vertical = 6.dp),
+  ) {
+    Text(
+      text = label,
+      color = if (selected) White else White.copy(alpha = 0.65f),
+      fontSize = 12.sp,
+      fontWeight = FontWeight.Bold,
+    )
+  }
+}

--- a/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/glass/GlassTooltipScreen.kt
+++ b/samples-shared/src/commonMain/kotlin/com/skydoves/balloon/sample/glass/GlassTooltipScreen.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2019 skydoves
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.balloon.sample.glass
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.skydoves.balloon.BalloonHost
+import com.skydoves.cloudy.rememberSky
+import com.skydoves.cloudy.sky
+
+/**
+ * A tooltip that is made of glass instead of paint.
+ *
+ * The usual reason a tooltip hurts is that it is opaque. It lands on top of the thing you just
+ * tapped and hides the neighbours you were comparing it against, which is the worst moment to
+ * take context away. A glass tooltip keeps the grid readable underneath while staying legible
+ * itself, so the answer and the question stay on screen together.
+ *
+ * Three pieces make that work, and they belong to two libraries:
+ *
+ * - `Modifier.sky(sky)` marks the grid as the content to capture.
+ * - `Modifier.cloudy(sky = sky, ...)` draws that capture back, blurred, inside the balloon.
+ * - `Modifier.liquidGlass(...)` bends it at the edges so the panel reads as a lens rather
+ *   than as a flat translucent rectangle.
+ *
+ * The part worth knowing is that the balloon body lives in a `Popup`, which is its own window
+ * on Android and its own scene layer on the Skia targets. The backdrop is still sampled at the
+ * right place, because `Sky` holds a shared capture rather than reading whatever happens to be
+ * behind the current window.
+ *
+ * @param onBack invoked when the back affordance is pressed.
+ */
+@Composable
+public fun GlassTooltipScreen(onBack: () -> Unit = {}) {
+  val sky = rememberSky()
+  var lensEnabled by remember { mutableStateOf(true) }
+  var blurRadius by remember { mutableStateOf(28) }
+
+  BalloonHost {
+    Box(modifier = Modifier.fillMaxSize().background(Backdrop)) {
+      // The capture source is the whole screen behind the glass, top bar included.
+      //
+      // Deliberately a plain scrolling Column rather than a `LazyVerticalGrid`. A lazy
+      // container as the capture source draws nothing at all on Android: the items compose
+      // and appear in the semantics tree, but no pixels reach the screen. The same code is
+      // fine on Desktop, and a non lazy source is fine on both. Eight tiles do not need
+      // recycling anyway.
+      Column(
+        modifier = Modifier
+          .fillMaxSize()
+          .sky(sky),
+      ) {
+        GlassTopBar(onBack = onBack)
+        Column(
+          modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 104.dp),
+          verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+          GalleryItems.chunked(2).forEach { row ->
+            Row(
+              modifier = Modifier.fillMaxWidth(),
+              horizontalArrangement = Arrangement.spacedBy(14.dp),
+            ) {
+              row.forEach { item ->
+                Box(modifier = Modifier.weight(1f)) {
+                  GalleryCard(
+                    item = item,
+                    sky = sky,
+                    blurRadius = blurRadius,
+                    lensEnabled = lensEnabled,
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+      GlassControls(
+        sky = sky,
+        lensEnabled = lensEnabled,
+        onLensChange = { lensEnabled = it },
+        blurRadius = blurRadius,
+        onBlurChange = { blurRadius = it },
+        modifier = Modifier.align(Alignment.BottomCenter),
+      )
+    }
+  }
+}


### PR DESCRIPTION
A tooltip is normally opaque, so it covers the neighbours you were comparing against at exactly the moment you wanted them. That is the case a glass surface solves rather than decorates, so the demo is a photo grid where each tile owns a balloon whose body is a frosted lens.

`Modifier.sky` marks the grid as the capture source, `Modifier.cloudy(sky = ...)` draws that capture back blurred inside the balloon, and `Modifier.liquidGlass` bends it near the edges. Blur radius and the lens are switchable so the parameters are visible rather than claimed. Verified on Android and Desktop.

Two things worth flagging:

- **`Modifier.sky` on a lazy container renders nothing on Android.** With `LazyVerticalGrid` as the capture source the tiles compose and appear in the semantics tree, but no pixels are drawn. The same code is fine on Desktop, and a plain scrolling `Column` is fine on both, so the demo uses one. Cloudy's own README example uses `LazyVerticalGrid` as the source, so this looks like a real bug on that side rather than a usage error here.
- **`cloudy` declares `minCompileSdk=37`.** The demo modules compile against 37; `:balloon` stays on 36 so the published AAR keeps asking consumers for 36, which it still does. `samples-shared` also drops `iosX64`, which cloudy does not publish; the library still targets it.

`spotlessCheck`, `apiCheck`, `desktopTest`, `testDebugUnitTest`, and every platform build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Glass Tooltips demo with gradient gallery cards and interactive tooltips.
  * Added controls to toggle lens effects and adjust blur intensity.
  * Added navigation between the main demo and the new Glass Tooltips screen.
  * Added support for the Cloudy visual effects library in demo applications.
* **Platform Updates**
  * Updated demo builds to use the latest Android SDK.
  * Removed the iOS x64 demo target while retaining arm64 targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->